### PR TITLE
Phase 3: Tier-1 adapters — L298N WheelchairDrive wrapper + R-Net/Shark/VR2 codec scaffolding

### DIFF
--- a/docs/beta/README.md
+++ b/docs/beta/README.md
@@ -1,0 +1,11 @@
+# Field beta program
+
+Phase 5 milestone. Five participants, indoor + sidewalk ODD, 30 days,
+zero unsafe events.
+
+| Doc | Purpose |
+|-----|---------|
+| [odd.md](odd.md) | Operational design domain |
+| [protocol.md](protocol.md) | Participant protocol & consent |
+| [incident_response.md](incident_response.md) | On-incident playbook |
+| [telemetry.md](telemetry.md) | What we collect, how it's stored |

--- a/docs/beta/incident_response.md
+++ b/docs/beta/incident_response.md
@@ -1,0 +1,28 @@
+# Incident response playbook
+
+If anything unexpected happens during a tele-op session.
+
+## Severities
+
+| Sev | Definition | Notify within | Engineering response |
+|-----|------------|---------------|----------------------|
+| **SEV-0** | Harm to person or property; rollover; injury | 15 min | All-hands; suspend all beta sessions until RCA |
+| **SEV-1** | Loss of control without harm; unexpected e-stop; wrong direction | 1 hour | On-call engineer; affected participant pauses until RCA |
+| **SEV-2** | Degraded service; high latency; battery scare; UI bug | next business day | Standard issue triage |
+| **SEV-3** | Cosmetic; minor confusion | weekly review | Backlog |
+
+## SEV-0 / SEV-1 sequence
+
+1. **Rider safety first.** If on, OEM joystick takes over. Power down chair if needed.
+2. Page on-call via PagerDuty / phone (per the duty roster).
+3. Engineer pulls device telemetry within 15 min (`telemetry/incident_pull.py <device_id> --since-30m`).
+4. Open incident issue in `Wheelchair-Bot/field-incidents` GitHub project; link telemetry.
+5. Suspend tele-op for affected participant via remote disable flag.
+6. RCA within 5 business days. Postmortem doc per `engineering:incident-response` template.
+7. Resolution gate: regression test added + HIL test added + safety review sign-off.
+
+## Reporting obligations
+
+- SEV-0: regulatory consultant within 24 h; post-market surveillance log
+- SEV-0 with harm: FDA MedWatch (US) / MHRA Yellow Card (UK) within statutory window
+- All SEVs: included in monthly safety report

--- a/docs/beta/odd.md
+++ b/docs/beta/odd.md
@@ -1,0 +1,21 @@
+# Operational Design Domain (ODD)
+
+Wheelchair-Bot field beta operates **only** within this envelope.
+Anything outside is unsupported and the system should refuse to
+enable tele-op.
+
+| Dimension | In-ODD | Out-of-ODD |
+|-----------|--------|------------|
+| Environment | Indoor; outdoor sidewalks; accessible building campuses | Public roads; vehicle lanes; rail crossings; tarmac; mines / industrial |
+| Lighting | Daylight or well-lit indoor (>=200 lux) | Night without comma's IR; storm conditions |
+| Weather | Dry; light drizzle OK | Heavy rain; snow; ice; standing water |
+| Temperature | 0 – 40 °C ambient | Outside range |
+| Speed cap | OEM chair's "indoor" profile (typ. 6 km/h) | High-speed outdoor profiles disabled in tele-op |
+| Surface | Smooth concrete, indoor flooring, packed dirt | Loose gravel; deep mud; stairs (always); slopes > OEM rating |
+| Battery | > 25 % | LVC engaged below 22.5 V regardless of % |
+| Network | LTE or Wi-Fi ≥ 1 Mbps, ≤ 200 ms RTT | Anything else → tele-op disabled; OEM joystick only |
+| Driver | Trained remote driver + present rider | Unattended tele-op |
+| Chair | Permobil M3 (alpha); add Quantum + Pride per beta protocol | Anything else |
+
+Geofencing for outdoor segments uses `liveLocationKalman` from comma.
+Tele-op enable gate checks ODD on every supervised loop iteration.

--- a/docs/beta/protocol.md
+++ b/docs/beta/protocol.md
@@ -1,0 +1,37 @@
+# Beta participant protocol
+
+5 participants. 30 days. IRB-approved consent.
+
+## Eligibility
+
+- Rider over 18, regular user of a compatible powered wheelchair
+- Caregiver / remote driver willing to participate
+- Stable home network ≥ 1 Mbps up
+- Willing to accept telemetry collection per [telemetry.md](telemetry.md)
+
+## Onboarding
+
+1. Engineer site visit: install adapter board + comma 3X + e-stop relay
+2. Pair phone + browser via QR (Phase 2 auth)
+3. 60-min training: tele-op interface, deadman discipline, e-stop reset
+4. Supervised first session in the participant's primary indoor environment
+5. Sign daily log of any tele-op session
+
+## Daily ops
+
+- Tele-op sessions limited to 60 min initially; extended after 14 days clean
+- Mandatory weekly check-in call
+- Any S0 telemetry event triggers immediate review; tele-op disabled until cleared
+
+## Exit criteria
+
+Beta successful if at end of 30 days for all 5 participants:
+- Zero S0 incidents (no e-stop activation outside operator intent)
+- ≤ 2 S1 incidents per participant (any control degradation)
+- Subjective usability score ≥ 4/5 on post-study questionnaire
+- No equipment damage to chair or environment
+
+Beta fails — and ships do not move to general availability — if any of:
+- Any harm to rider or third party
+- Any rollover, even if no harm
+- Two or more network-loss incidents within a single week

--- a/docs/beta/telemetry.md
+++ b/docs/beta/telemetry.md
@@ -1,0 +1,39 @@
+# Telemetry — what we collect and why
+
+Beta participants give informed consent for the collection of the
+following data. Personally identifying information is **never**
+collected by the device; PII lives only in the paired-device registry
+on the server.
+
+## Collected
+
+| Field | Rate | Reason |
+|-------|------|--------|
+| `device_id` (UUID) | per session | join key |
+| Wheelchair state (linear/angular velocity, battery %, motor currents) | 10 Hz | safety RCA, performance |
+| Tele-op latency RTT | 1 Hz | network QoS |
+| Watchdog kicks vs. expiries | event | safety |
+| E-stop engagements (reason + timestamp) | event | safety |
+| Adapter codec stats (frames decoded / encoded / rejected) | 1 Hz | regression detection |
+| Anonymised location (~100 m grid) | 1 Hz | ODD validation |
+| App / device versions | per session | OTA + bug correlation |
+
+## Not collected
+
+- Camera frames
+- Audio
+- Exact GPS coordinates
+- Names, addresses, payment info
+- Health information
+
+## Storage
+
+- Encrypted in-transit (TLS 1.3) and at-rest (S3 SSE-KMS).
+- 90-day rolling retention for routine fields; **permanent** for SEV-0/1 incident snapshots.
+- Aggregated, anonymised summaries published quarterly.
+
+## Withdrawal
+
+Participants can revoke consent at any time. On revocation:
+- Device removed from registry within 24 h.
+- All collected telemetry deleted within 30 days *except* SEV-0/1 incident records (legal hold).

--- a/docs/comma/README.md
+++ b/docs/comma/README.md
@@ -1,0 +1,13 @@
+# comma.ai integration
+
+Phase 4 of the audit roadmap. Brings the comma three / 3X (and, when
+its SDK ships, the comma four) up as the compute + sensor + CAN-bridge
+platform for shipping Wheelchair-Bot units.
+
+| Doc | Issue | Status |
+|-----|-------|--------|
+| [setup.md](setup.md) | [#42 G-24](https://github.com/Wheelchair-Bot/Wheelchair-Bot/issues/42) | bench bring-up |
+| [cereal_mapping.md](cereal_mapping.md) | [#42 G-24](https://github.com/Wheelchair-Bot/Wheelchair-Bot/issues/42) | topic table |
+| [safety_model.md](safety_model.md) | [#42 G-24](https://github.com/Wheelchair-Bot/Wheelchair-Bot/issues/42) | panda safety modes |
+| [perception.md](perception.md) | [#43 G-25](https://github.com/Wheelchair-Bot/Wheelchair-Bot/issues/43) | camera / IMU / GPS reuse |
+| [model_runtime.md](model_runtime.md) | [#44 G-26](https://github.com/Wheelchair-Bot/Wheelchair-Bot/issues/44) | openpilot model integration |

--- a/docs/comma/cereal_mapping.md
+++ b/docs/comma/cereal_mapping.md
@@ -1,0 +1,16 @@
+# Cereal topic mapping
+
+| Cereal topic | Direction | Wheelchair-Bot consumer/producer | Notes |
+|--------------|-----------|----------------------------------|-------|
+| `pandaStates` | comma → wcbot | `wheelchair.safety.comma_watchdog` (Phase 4 follow-up) | engages local stop on heartbeat loss |
+| `can` | bi-directional | `wheelchair.drives.comma_panda.CommaPandaDrive` | sniff (decode) + inject (encode) |
+| `sendcan` | wcbot → comma | `CommaPandaDrive.send` | gated by panda safety mode |
+| `carState` | comma → wcbot | mapped to `wheelchair.interfaces.WheelchairState` | reuse OpenPilot's KalmanFilter |
+| `carControl` | wcbot → comma | from tele-op `(linear, angular)` | desired velocity |
+| `roadCameraState` / `wideRoadCameraState` | comma → wcbot → client | streamed to tele-op WebRTC track | Phase 4 follow-up |
+| `driverMonitoringState` | comma → wcbot | folds into `DeadmanSwitch.press()` | optional gaze-based deadman |
+| `liveLocationKalman` | comma → wcbot | telemetry + path replay | |
+| `wcbotState` | local | `WheelchairState` snapshot | wheelchair-specific |
+| `wcbotControl` | local | desired motion + deadman | replaces direct fn calls in supervised process |
+| `wcbotSafety` | local | `EStopEvent` fan-out | |
+| `wcbotTelemetry` | local → cloud | rolled-up state for field beta | Phase 5 |

--- a/docs/comma/model_runtime.md
+++ b/docs/comma/model_runtime.md
@@ -1,0 +1,24 @@
+# Model runtime (G-26)
+
+Phase 4d — load an openpilot-style ONNX model into the supervised
+process, with the wheelchair use-case constraints:
+
+- **No road operation.** Operational design domain is indoor + sidewalk only.
+- **Path-following only, no decision-making.** The model proposes a
+  short-horizon trajectory; the operator's tele-op input is the
+  authoritative source. Path proposals modulate speed limits and
+  obstacle warnings, never override deadman or e-stop.
+- **Comma DSP / GPU for inference**; do not run on Pi-class compute.
+
+## File layout
+
+```
+src/wheelchair/perception/
+    __init__.py
+    model_loader.py     # ONNX loader; warms compute on supervisor start
+    inference.py        # runs at 20 Hz against roadCameraState
+    obstacle_map.py     # turns model output into a depth grid
+    policy.py           # speed-limit + warning logic (no actuation)
+```
+
+Lands in a follow-up to the Phase 4 PR once the bench bring-up is solid.

--- a/docs/comma/perception.md
+++ b/docs/comma/perception.md
@@ -1,0 +1,22 @@
+# Perception via comma sensors (G-25)
+
+comma 3X exposes (via cereal):
+- dual road cameras (forward + wide) — `roadCameraState`, `wideRoadCameraState`
+- driver camera — `driverCameraState`
+- BMI088 IMU at 100 Hz
+- u-blox NEO-M9N GPS
+- Snapdragon ISP + GPU
+
+For Wheelchair-Bot we re-purpose them:
+
+| Sensor | OpenPilot use | Wheelchair-Bot use |
+|--------|---------------|---------------------|
+| Forward road cam | lane / lead-car | obstacle avoidance, tele-op video, doorway alignment |
+| Wide road cam | adjacent lanes | side clearance check |
+| Driver cam | gaze / drowsy | operator presence (optional deadman input) |
+| IMU | localisation, gyro health | tilt cutoff (Phase 1 `TiltMonitor` feeds from this) |
+| GPS | location | telemetry / geofencing for beta |
+
+Forwarding the road camera to the tele-op WebRTC track replaces the
+Phase 2 stubbed video path (the one that needed a Pi camera). On a
+comma device we get a properly time-synced H.265 stream for free.

--- a/docs/comma/safety_model.md
+++ b/docs/comma/safety_model.md
@@ -1,0 +1,59 @@
+# Panda + Wheelchair-Bot safety model
+
+The panda is a **second independent watchdog** on top of the software
+`CommaPandaDrive`. This is the property that makes the comma stack
+attractive for safety-critical control.
+
+## Boot-time
+
+1. Comma 3X boots, openpilot launches, panda enters `SILENT` mode by default.
+2. Wheelchair-Bot supervisor launches; `CommaPandaDrive.__init__` does
+   NOT yet enable output.
+3. Operator pairs their phone (auth handshake from Phase 2).
+4. Operator presses-and-holds physical deadman on the OEM joystick AND
+   the tele-op deadman in their phone app simultaneously.
+5. Supervisor calls `PandaBridge.enable_output()` → `set_safety_mode(ALLOUTPUT)`.
+6. Heartbeats start at 100 Hz.
+
+## Runtime
+
+```
+                  ┌───────────────────────────┐
+                  │ Wheelchair-Bot supervisor │
+                  └─────────────┬─────────────┘
+                                │ heartbeat (100 Hz)
+                                ▼
+                  ┌───────────────────────────┐
+                  │ panda firmware            │
+                  │   safety_mode=ALLOUTPUT   │
+                  │   heartbeat watchdog      │
+                  └─────────────┬─────────────┘
+                                │ sendcan
+                                ▼
+                      Chair controller CAN bus
+```
+
+Loss of heartbeat for >500 ms → panda drops to `NOOUTPUT`. Drive stops.
+Wheelchair-Bot software watchdog `CommandWatchdog` independently catches
+the same condition and engages `EmergencyStop`. The two watchdogs are
+intentionally redundant.
+
+## Failure modes covered
+
+| Failure | Caught by | Recovery |
+|---------|-----------|----------|
+| Linux crash | panda heartbeat timeout | manual reset of EmergencyStop |
+| Python GIL stall | panda heartbeat timeout | as above |
+| USB cable unplug | panda heartbeat timeout | as above |
+| Wi-Fi loss → tele-op disconnect | `wheelchair.app.server` calls `safety_stop("ws_disconnect")` | operator reconnect + clear |
+| OEM joystick deadman release | dual-purpose deadman wire (`deadman_wiring.md`) | re-grip |
+| Tele-op deadman release | `DeadmanSwitch.release()` | re-press |
+| Tilt / current / LVC | Phase 1 monitors | manual reset |
+
+## Out of scope here
+
+- The panda's *built-in* model-specific safety modes for cars: we don't
+  use them; this is a wheelchair, not an automobile. We use panda only
+  as a CAN bridge + heartbeat-gated output.
+- Custom panda firmware: we should stay on stock for as long as
+  possible to inherit upstream fixes.

--- a/docs/comma/setup.md
+++ b/docs/comma/setup.md
@@ -1,0 +1,62 @@
+# comma 3X bench bring-up
+
+Goal: get a comma 3X reading CAN from a bench harness and forwarding to
+Wheelchair-Bot's `CommaPandaDrive`. No chair on the floor.
+
+## Hardware
+
+- comma 3X (or comma three — same software target, just better thermals on 3X)
+- red panda or panda tres (CAN-FD where available)
+- OBD-C cable + breakout to DB9 (R-Net) or DCI (Shark) or 4-pin (VR2)
+- Bench wheelchair-controller (Permobil M3 ICS for the alpha)
+- Lab PSU 24 V / 5 A
+- E-stop relay (see `docs/hardware/estop_relay_v1.md`)
+
+## Topology
+
+```
+       +24V lab PSU                       +12V comma 3X
+            │                                  │
+            ▼                                  ▼
+     ┌──────────────┐                  ┌──────────────────┐
+     │ Permobil M3  │ ◄──── CAN ──────►│ red panda (CAN0) │ ◄─USB─ comma 3X
+     │ ICS bench    │                  │                  │
+     └──────────────┘                  └──────────────────┘
+            │                                  │
+            └─────── e-stop relay ─────────────┘
+                          ▲
+                          │
+                  user mushroom button
+```
+
+## Software
+
+1. Flash comma 3X with current openpilot dev branch (or a Wheelchair-Bot
+   fork once we have one).
+2. SSH into the device. Clone Wheelchair-Bot into `/data/wcbot`.
+3. Add a manager entry:
+   ```python
+   from wheelchair.comma.supervisor import Supervisor, ProcessSpec
+   sup = Supervisor(
+       processes=[
+           ProcessSpec("teleop", run_teleop_server, essential=True),
+           ProcessSpec("comma_drive", run_comma_drive_loop, essential=True),
+           ProcessSpec("telemetry", run_telemetry_uploader, essential=False),
+       ],
+       on_essential_failure=lambda _n: emergency_stop.engage(EStopReason.EXTERNAL),
+   )
+   sup.start()
+   ```
+4. `cd /data/wcbot && python -m wheelchair.cli --drive comma_panda --adapter rnet`.
+5. Watch `pandaStates` and `wcbotState` with `cereal_log` to confirm.
+
+## Smoke checks
+
+- `panda.set_safety_mode(ALLOUTPUT)` only when we heartbeat at ≥10 Hz; loss of heartbeat drops to `NOOUTPUT` within 500 ms.
+- HIL test `test_can_bus_fault_reverts_to_local_safe_state` passes against the bench rig.
+
+## Out of scope (Phase 4)
+
+- comma four — wait for SDK availability.
+- Vehicle-in-loop on a real chair — Phase 5.
+- Field beta — Phase 5.

--- a/docs/hardware/wiring/README.md
+++ b/docs/hardware/wiring/README.md
@@ -1,0 +1,19 @@
+# Wheelchair-bus wiring & pinouts
+
+Per-family safe-tap procedures and pinouts.
+
+> **Read this first.** Tapping a wheelchair control bus is electrically
+> safe if done carefully but can void the OEM warranty and, if you bridge
+> the wrong pins, can destroy the chair's controller. Always:
+> 1. Disconnect the battery before opening any harness.
+> 2. Buzz pin-to-pin with a meter before powering on.
+> 3. Use isolated CAN transceivers (e.g. ISO1050) for the first prototype.
+> 4. Keep the OEM joystick connected during all of Phase 3 (adapter mode).
+
+| Family | Doc | Issue |
+|--------|-----|-------|
+| R-Net (DB9) | [rnet_db9_pinout.md](rnet_db9_pinout.md) | [#29 G-11](https://github.com/Wheelchair-Bot/Wheelchair-Bot/issues/29) |
+| Shark / DX | [shark_dci.md](shark_dci.md) | #29 |
+| VR2 / Pilot+ | [vr2.md](vr2.md) | #29 |
+| LiNX | (Phase 5) | #29 |
+| Q-Logic | (Phase 5) | #29 |

--- a/docs/hardware/wiring/rnet_db9_pinout.md
+++ b/docs/hardware/wiring/rnet_db9_pinout.md
@@ -1,0 +1,57 @@
+# R-Net DB9 pinout (host port)
+
+Used on most R-Net chairs (Permobil, Quantum, some Sunrise). The DB9
+on the joystick or seat module exposes the bus to a host (PC programmer,
+attendant control, our adapter).
+
+## Pinout (DB9 female, looking into the connector)
+
+```
+   1  2  3  4  5
+    o  o  o  o  o
+     o  o  o  o
+     6  7  8  9
+```
+
+| Pin | Signal | Notes |
+|-----|--------|-------|
+| 1 | +12 V (switched) | from chair battery via DC-DC; ~500 mA available |
+| 2 | CAN_H | 125 kbps, ISO 11898-2 |
+| 3 | CAN_L | |
+| 4 | GND | chassis ground |
+| 5 | (reserved) | leave NC |
+| 6 | INHIBIT | active low — pulls down to inhibit drive (latched) |
+| 7 | LOCK | active low — engages park brake |
+| 8 | +5 V (logic) | low-current logic supply |
+| 9 | (reserved) | NC |
+
+## Safe-tap procedure
+
+1. Battery off.
+2. Insert a DB9 M-F passthrough with all pins broken out to test points.
+3. Battery on. Confirm with meter: pin 1 ≈ 12 V, pin 8 ≈ 5 V, pin 4 GND.
+4. Confirm CAN with logic analyser; should see ~10 ms cadence joystick
+   frames at 125 kbps.
+5. Capture 60 s baseline (joystick stationary) → `tests/captures/rnet_idle.csv`.
+6. Capture 60 s drive sequence (forward, back, L, R) → `rnet_drive.csv`.
+7. Disconnect; analyse offline.
+
+## Adapter board
+
+The Phase 3 adapter is a small PCB with:
+- ISO1050 isolated CAN transceiver
+- 12 V → 5 V DC-DC for the RP2040 supervisor
+- DB9 M passthrough + 3.5 mm e-stop jack (wired to estop_relay_v1)
+
+Only after captures match the adapter skeleton in
+`src/wheelchair/adapters/rnet.py` does the adapter ever drive the
+`INHIBIT` pin or inject joystick frames.
+
+## Inject mode (the "live" mode)
+
+Two safety locks must be cleared before inject mode is permitted:
+
+1. The hardware e-stop relay must be present and verified (HIL test).
+2. The user must hold the **physical** deadman on the OEM joystick at
+   the same time as their tele-op input — true joint authority. The
+   OEM joystick remains the legal control.

--- a/docs/hardware/wiring/shark_dci.md
+++ b/docs/hardware/wiring/shark_dci.md
@@ -1,0 +1,22 @@
+# Shark / DX (Dynamic Controls) DCI bus
+
+DCI is a proprietary 4-pin bus on most Invacare and Pride chairs with
+Dynamic Controls electronics. Some newer chairs expose CAN at 250 kbps
+on the same physical connector.
+
+## Pinout (4-pin square, looking into harness)
+
+| Pin | Signal | Notes |
+|-----|--------|-------|
+| 1 | +24 V (switched) | from battery; ~200 mA |
+| 2 | DCI_A / CAN_H | |
+| 3 | DCI_B / CAN_L | |
+| 4 | GND | |
+
+## Safe-tap
+
+Same procedure as `rnet_db9_pinout.md`. If you see CAN cadence at
+250 kbps, the chair is on the newer CAN-DCI; otherwise treat as a
+differential DCI bus and use the Dynamic Controls programming dongle
+schematic (see Dynamic Controls Service Manual, chapter 4) as a guide
+for line termination.

--- a/docs/hardware/wiring/vr2.md
+++ b/docs/hardware/wiring/vr2.md
@@ -1,0 +1,17 @@
+# VR2 / Pilot+ (PG Drives)
+
+Common on Sunrise Medical, older Permobil mid-tier chairs. Same DB9
+host connector as R-Net mechanically but **different bitrate and
+message set** — do not assume the R-Net adapter will work on VR2.
+
+## Differences vs. R-Net
+
+| | R-Net | VR2 |
+|---|-------|-----|
+| Bitrate | 125 kbps | 125 kbps |
+| Joystick frame ID | `0x02000000` (provisional) | `0x0CFF1000` (provisional) |
+| Joystick payload | two signed-8 | two signed-16 LE |
+| Heartbeat | required | required, different ID |
+| Programming tool | R-Net PG Programmer | PG Drives PC Programmer |
+
+Pinout is identical to `rnet_db9_pinout.md`.

--- a/docs/regulatory/README.md
+++ b/docs/regulatory/README.md
@@ -1,0 +1,15 @@
+# Regulatory documentation
+
+Phase 5 of the audit roadmap. These docs are **templates and trackers**,
+not legal advice. Engage qualified regulatory counsel before any
+submission. Items here are work-in-progress versions; final dossiers
+are owned by the regulatory consultant of record once Phase 5b lands.
+
+| Doc | Purpose | Owner | Status |
+|-----|---------|-------|--------|
+| [risk_file.md](risk_file.md) | IEC 60601-1 / ISO 14971 risk file | regulatory consultant | v0.1 skeleton |
+| [iec_60601_mapping.md](iec_60601_mapping.md) | Clause-by-clause coverage of IEC 60601-1 + -2-1 | engineering | partial |
+| [iso_7176_14.md](iso_7176_14.md) | Wheelchair controller compliance (ISO 7176-14) | engineering | partial |
+| [fda_presub.md](fda_presub.md) | FDA pre-submission template (US) | regulatory | template |
+| [mhra_summary.md](mhra_summary.md) | UK MHRA pre-market summary | regulatory | template |
+| [openpilot_attribution.md](openpilot_attribution.md) | Attribution + licence inventory | engineering | initial |

--- a/docs/regulatory/fda_presub.md
+++ b/docs/regulatory/fda_presub.md
@@ -1,0 +1,51 @@
+# FDA Q-Submission (pre-submission) — template
+
+For the US FDA Q-Submission program — formal feedback before a 510(k)
+or De Novo submission. Reference: FDA guidance "Requests for Feedback
+and Meetings for Medical Device Submissions" (2023).
+
+> ⚠️ Template only. Final submission owned by regulatory counsel.
+
+## 1. Background
+
+Wheelchair-Bot is a retrofit tele-operation system for commercially
+available powered wheelchairs. The host chair is a class II device
+(21 CFR 890.3700). Our retrofit adds:
+
+- Compute + sensors (comma 3X)
+- A CAN-bus adapter (one of: R-Net, Shark/DX, VR2)
+- Smartphone / web tele-op client
+- Software safety layers
+
+## 2. Regulatory questions for FDA
+
+1. Does this retrofit re-classify the host chair, or remain a class II
+   accessory under 21 CFR 890.3700?
+2. Is a De Novo submission preferred over 510(k) given the lack of a
+   direct predicate for tele-operation of a powered wheelchair?
+3. Are the proposed software risk-controls (dual watchdog, hardware
+   e-stop relay, panda safety mode) adequate per the Software in a
+   Medical Device (SaMD) guidance?
+4. Will the comma 3X compute platform require its own component-level
+   submission, or can it be qualified as a sub-system?
+5. What clinical evidence is expected for class II tele-operation
+   (literature review vs. small pivotal study)?
+
+## 3. Proposed indications for use
+
+Wheelchair-Bot is intended for **assisted tele-operation** of a
+compatible commercial powered wheelchair by a designated remote driver
+under continuous supervision of the rider or rider's caregiver, in
+indoor and sidewalk environments. The system is not intended for
+unsupervised autonomous operation, public-road use, or any use case
+outside the operational design domain in [risk_file.md](risk_file.md).
+
+## 4. Pre-submission package contents (planned)
+
+- Cover letter
+- Risk file ([risk_file.md](risk_file.md)) expanded by consultant
+- Software description per FDA SaMD guidance
+- IEC 60601-1 + ISO 7176-14 compliance plan
+- Cybersecurity plan per FDA 2023 final guidance (auth, OTA signing)
+- Labelling drafts
+- Verification & validation plan summary

--- a/docs/regulatory/iec_60601_mapping.md
+++ b/docs/regulatory/iec_60601_mapping.md
@@ -1,0 +1,39 @@
+# IEC 60601-1 + 60601-2-1 clause coverage (partial)
+
+Mapping of relevant clauses to Wheelchair-Bot artefacts. **Numerous
+gaps**; this file is a tracker, not evidence of compliance.
+
+| Clause | Title | Applicable? | Evidence / artefact |
+|--------|-------|-------------|---------------------|
+| 4.2 | Risk management process | yes | [risk_file.md](risk_file.md) |
+| 4.3 | Essential performance | yes | TBD — define minimum acceptable motion control |
+| 4.5 | Equivalent safety | yes | dual-watchdog architecture; see [comma/safety_model.md](../comma/safety_model.md) |
+| 4.8 | Components of high integrity | yes | hardware e-stop relay (estop_relay_v1) latching; key switch reset |
+| 5.4 | Process for design and development | yes | this repository + linked issues + PRs |
+| 7.2 | Markings on outside of ME equipment | TBD | manufacturing follow-up |
+| 8.4 | Excessive currents | yes | OvercurrentMonitor (G-02), INA226 hardware |
+| 8.7 | Insulation | TBD | mechanical PCB design |
+| 9 | Mechanical hazards | yes | tilt cutoff; OEM chair retains weight rating |
+| 11.1 | Excessive temperatures | yes | thermal model in emulator; comma 3X sealed enclosure |
+| 11.6.5 | Spillage | yes | indoor use; sealed enclosures on comma + e-stop board |
+| 12 | Accuracy of controls / instruments | yes | tele-op latency budget < 100 ms; tracked in telemetry |
+| 14 | Programmable electrical medical systems (PEMS) | **yes — core** | IEC 62304 process needed; see below |
+| 17 | EMC | yes | IEC 60601-1-2 chamber test scheduled Phase 5b |
+
+## IEC 62304 (software lifecycle) — interim plan
+
+| Activity | Class | Where in repo |
+|----------|-------|---------------|
+| Software development plan | C (safety-critical) | this roadmap (`docs/AUDIT_planning.md`) |
+| Risk-control measures | C | `src/wheelchair/safety/` + tests |
+| Software requirements | C | issues #19..#26 + per-PR spec |
+| Architectural design | C | `docs/AUDIT_architecture.md` |
+| Detailed design | C | code + comments |
+| Unit + integration tests | C | `src/tests/` + nightly HIL |
+| Problem resolution | C | GitHub Issues + the field-incidents project |
+| Maintenance plan | C | OTA cadence + rollback procedure (Phase 5b) |
+
+## IEC 60601-2-1
+
+Particular standards for powered wheelchairs. Per-clause mapping lands
+when a regulatory consultant engages (Phase 5).

--- a/docs/regulatory/iso_7176_14.md
+++ b/docs/regulatory/iso_7176_14.md
@@ -1,0 +1,20 @@
+# ISO 7176-14 (electrical wheelchair controllers) — coverage
+
+ISO 7176-14 specifies requirements and test methods for electrical
+control systems on wheelchairs. We are a *controller adapter*, not a
+controller — but several clauses still bind us because we modulate
+control signals.
+
+| Clause | Topic | Applies to us? | Coverage |
+|--------|-------|----------------|----------|
+| 7.1 | Power-on stability | yes | panda boots in `NOOUTPUT`; explicit enable required |
+| 7.2 | Drive direction integrity | yes | adapter encode/decode symmetry tests; provisional codec gate |
+| 7.3 | Speed control | yes | Phase 1 `SpeedLimiter` (carried forward from legacy `wheelchair_bot.safety`) |
+| 7.4 | Emergency stop performance | yes | `EmergencyStop` + relay; <50 ms drop time (G-04 HIL test) |
+| 7.5 | Operator-present switch | yes | `DeadmanSwitch` software + dual-purpose wire |
+| 8.x | EMC | yes | covered by IEC 60601-1-2 chamber test plan |
+| 9 | Environmental | yes | indoor + sidewalk ODD; ratings inherited from comma 3X enclosure |
+| 10 | Documentation | yes | this repo + user manual (Phase 5) |
+
+A formal ISO 7176-14 test campaign needs an accredited lab. Pre-test
+covers above; submission lands in Phase 5b.

--- a/docs/regulatory/mhra_summary.md
+++ b/docs/regulatory/mhra_summary.md
@@ -1,0 +1,12 @@
+# UK MHRA pre-market summary — template
+
+Post-Brexit, the UK MHRA manages medical-device registration under the
+UK MDR 2002 (as amended). Powered wheelchairs are class I (general)
+unless the modification raises the classification.
+
+Wheelchair-Bot retrofit is likely **class IIa** in the UK due to
+modulation of control signals on a class I host device. UKCA marking
+required for placement on the GB market; CE under EU MDR continues to
+apply for NI and EU.
+
+Template body lands once regulatory counsel confirms classification.

--- a/docs/regulatory/openpilot_attribution.md
+++ b/docs/regulatory/openpilot_attribution.md
@@ -1,0 +1,19 @@
+# Licence inventory & attribution
+
+Wheelchair-Bot is MIT-licensed (see [LICENSE](../../LICENSE)).
+
+## Reused / borrowed code & ideas
+
+| Component | Upstream | Licence | How we use it |
+|-----------|----------|---------|---------------|
+| openpilot manager pattern | github.com/commaai/openpilot | MIT | inspiration for `wheelchair.comma.supervisor` (no code copy) |
+| cereal IPC | github.com/commaai/cereal | MIT | runtime dependency on comma device; not bundled |
+| panda firmware + python | github.com/commaai/panda | MIT | runtime dependency on comma device; not bundled |
+| cabana capture format | github.com/commaai/openpilot | MIT | file format only; our `replay.py` parses CSV |
+| FastAPI | github.com/tiangolo/fastapi | MIT | direct dep |
+| Pydantic | github.com/pydantic/pydantic | MIT | direct dep |
+| Three.js (simulator UI) | github.com/mrdoob/three.js | MIT | direct dep |
+| markdown-it (site) | github.com/markdown-it/markdown-it | MIT | direct dep |
+
+No GPL / AGPL code in the runtime tree. Regulatory submissions get a
+fresh SBOM (cyclonedx) from `scripts/lock_deps.sh` outputs.

--- a/docs/regulatory/risk_file.md
+++ b/docs/regulatory/risk_file.md
@@ -1,0 +1,82 @@
+# Wheelchair-Bot risk file — v0.1 (skeleton)
+
+Per **IEC 60601-1 §4.2** and **ISO 14971** risk-management process.
+
+> ⚠️ This is a draft skeleton produced by engineering for the regulatory
+> consultant to expand into a formal dossier. It is not a substitute
+> for a qualified ISO 14971 process. **Not for submission.**
+
+## 1. Intended use
+
+A retrofittable computer + sensor pack that allows a qualified rider or
+attendant to **tele-operate** a commercial powered wheelchair using a
+smartphone or browser interface. Tele-operation is supervised at all
+times by the rider or a designated remote driver. The device does
+**not** replace the OEM joystick and does **not** make autonomous
+decisions about destination, route, or speed.
+
+Operational design domain (ODD):
+- Indoor (homes, care facilities, accessible buildings)
+- Outdoor sidewalks and accessible pathways
+- Daylight or well-lit indoor conditions
+- Single occupant; rider weight within OEM chair's spec
+- Ambient temperature 0–40 °C
+- Not on public roads, not in vehicle lanes, not in airport tarmac, not in mines/industrial sites
+
+## 2. Stakeholders
+
+- Primary user — wheelchair rider
+- Secondary user — remote driver (caregiver / family / clinician)
+- Maintainer — clinician or technician who pairs devices and reviews logs
+- Manufacturer — Wheelchair-Bot project
+
+## 3. Hazards & risk register (initial pass)
+
+| ID | Hazard | Cause | Sequence of events | Harm | Severity | Probability | Mitigation | Residual |
+|----|--------|-------|--------------------|------|----------|-------------|------------|----------|
+| H-01 | Unintended motion | Stale tele-op command | network lag → command repeats | minor injury, property damage | 3 | 3 | `CommandWatchdog` (G-01) + panda heartbeat watchdog | 2×2 |
+| H-02 | Unintended motion | Software crash | Python OOM → no further commands | as above | 3 | 2 | dual watchdog + e-stop relay (G-04) | 2×1 |
+| H-03 | Rider lost control | Authority conflict | tele-op contradicts OEM joystick | minor injury | 3 | 2 | OEM joystick is authoritative; dual deadman required in inject mode | 2×1 |
+| H-04 | Rollover | Tilt while turning | high speed on uneven ground | major injury | 4 | 2 | `TiltMonitor` (G-05) + speed-on-tilt limiter | 3×1 |
+| H-05 | Thermal runaway | Motor overcurrent | locked rotor against obstacle | fire, burns | 4 | 1 | `OvercurrentMonitor` (G-02) at MCU level | 3×1 |
+| H-06 | Loss of mobility | Battery drained | extended tele-op with display on | stranded user | 2 | 3 | `LowVoltageCutoff` (G-06) at 22.5 V | 2×2 |
+| H-07 | Unauthorised control | Stolen / replayed token | weak auth | privacy + safety | 4 | 2 | bearer token + sha256-hashed store + TLS (G-23) | 3×1 |
+| H-08 | Privacy leak | Camera stream | unencrypted WebRTC | privacy | 3 | 2 | DTLS-SRTP (WebRTC default); auth-gated signaling | 2×1 |
+| H-09 | Bus collision | Concurrent OEM + adapter | both writing R-Net joystick frames | erratic motion | 3 | 2 | adapter mode requires OEM deadman released; rate-limit | 2×1 |
+| H-10 | Firmware regression | OTA breaks adapter | new R-Net version changes codec | unintended motion | 3 | 2 | per-chair captures committed to CI; nightly replay | 2×1 |
+
+Severity / Probability scale: 1 (negligible) → 5 (catastrophic).
+
+## 4. Risk-control verification matrix
+
+Each control points to the test that verifies it. CI must run those
+tests on every commit (`@pytest.mark.safety` job) and the HIL rig must
+run them nightly (`@pytest.mark.hil`).
+
+| Control | Software test | HIL test | Field test |
+|---------|---------------|----------|------------|
+| `CommandWatchdog` | `test_watchdog_stops_motors_within_100ms_of_command_loss` | `test_watchdog_drop_after_kill_9` | telemetry sentinel |
+| `DeadmanSwitch` GPIO | `test_deadman_release_drives_pwm_to_zero_at_gpio_level` | same name, logic-analyser-asserted | n/a |
+| `TiltMonitor` | `test_tilt_cutoff_at_25_deg_sustains_under_vibration` | manual tilt-table test | beta opt-in only |
+| `LowVoltageCutoff` | `test_lvc_cuts_at_22_5V_for_24V_pack` | bench PSU sweep | telemetry alert |
+| `OvercurrentMonitor` | `test_overcurrent_uses_max_of_both_motors` | `test_overcurrent_trip_within_one_pwm_cycle` | telemetry alert |
+| `EmergencyStop` latch | `test_estop_is_latched_until_cleared` | full-stack | incident log |
+| Hardware e-stop relay | n/a | `test_estop_drop_time` | quarterly inspection |
+| Panda safety mode | `test_panda_blocks_send_in_nooutput` | bench bring-up | continuous |
+
+## 5. Post-market surveillance
+
+- Telemetry uploader (Phase 5) writes anonymised event logs to S3.
+- Any S0 event (e-stop engagement during tele-op, watchdog timeout,
+  current trip) opens an issue in the field-incidents GitHub project
+  within 24 h.
+- Quarterly review by regulatory consultant.
+
+## 6. Open items for regulatory counsel
+
+- Classification under FDA 21 CFR 890.3700 (powered wheelchair) — does
+  this retrofit re-classify the host chair?
+- EU MDR 2017/745 — class I or II? Notified body needed?
+- ISO 14971 risk acceptability criteria — formal numeric thresholds.
+- ISO 7176-14 — full controller compliance test plan.
+- IEC 60601-1-2 EMC — chamber test in Phase 5b.

--- a/src/tests/test_adapters.py
+++ b/src/tests/test_adapters.py
@@ -1,0 +1,54 @@
+"""Unit tests for the controller-family adapter skeletons.
+
+These exercise the codec **shape**, not the (provisional) byte layouts.
+Real-protocol regression tests land in Phase 3 once captures from a
+Permobil M3 / Quantum Q6 / Pride Jazzy are committed to
+``tests/captures/`` (gitignored binary fixtures, replay CSVs go in
+``tests/captures/*.csv``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from wheelchair.adapters import (
+    CANAdapter,
+    ControllerSignal,
+    RNetAdapter,
+    SharkAdapter,
+    VR2Adapter,
+)
+
+
+ADAPTERS = [RNetAdapter(), SharkAdapter(), VR2Adapter()]
+
+
+@pytest.mark.parametrize("adapter", ADAPTERS, ids=lambda a: a.family)
+def test_adapter_round_trips_centre(adapter: CANAdapter) -> None:
+    sig_in = ControllerSignal(linear=0.0, angular=0.0, deadman_pressed=True)
+    frames = list(adapter.encode(sig_in))
+    assert frames, f"{adapter.family} produced no frames"
+    sig_out = adapter.decode(frames[0])
+    assert sig_out is not None
+    assert abs(sig_out.linear) < 0.02
+    assert abs(sig_out.angular) < 0.02
+
+
+@pytest.mark.parametrize("adapter", ADAPTERS, ids=lambda a: a.family)
+def test_adapter_safe_idle_decodes_to_zero(adapter: CANAdapter) -> None:
+    for frame in adapter.safe_idle_frames():
+        sig = adapter.decode(frame)
+        if sig is None:
+            continue
+        assert abs(sig.linear) < 0.02
+        assert abs(sig.angular) < 0.02
+
+
+@pytest.mark.parametrize("adapter", ADAPTERS, ids=lambda a: a.family)
+def test_adapter_releases_deadman_emits_safe(adapter: CANAdapter) -> None:
+    sig = ControllerSignal(linear=0.5, angular=0.5, deadman_pressed=False)
+    out = list(adapter.encode(sig))
+    decoded = adapter.decode(out[0]) if out else None
+    if decoded is not None:
+        assert abs(decoded.linear) < 0.02
+        assert abs(decoded.angular) < 0.02

--- a/src/tests/test_comma.py
+++ b/src/tests/test_comma.py
@@ -1,0 +1,130 @@
+"""Unit tests for the comma.ai integration scaffolding (Phase 4)."""
+
+from __future__ import annotations
+
+import pytest
+
+from wheelchair.adapters import RNetAdapter
+from wheelchair.comma.cereal_client import cereal_present, publish, recv, subscribe
+from wheelchair.comma.panda import FakePanda, PandaBridge, SafetyMode
+from wheelchair.comma.supervisor import ProcessSpec, Supervisor
+from wheelchair.comma.topics import Topic
+from wheelchair.drives.comma_panda import CommaPandaDrive
+
+
+# -------- cereal_client (fallback bus path) --------
+
+
+def test_cereal_client_fallback_round_trip() -> None:
+    # On a dev machine cereal isn't installed; we use the in-process bus.
+    if cereal_present():
+        pytest.skip("real cereal present; in-process fallback not exercised")
+    publish(Topic.WCBOT_STATE, {"linear_velocity": 0.5})
+    msg = recv(Topic.WCBOT_STATE)
+    assert msg == {"linear_velocity": 0.5}
+
+
+def test_cereal_client_subscribe_callback() -> None:
+    if cereal_present():
+        pytest.skip("subscribe() is fallback-only by design")
+    got: list = []
+    subscribe(Topic.WCBOT_TELEMETRY, lambda m: got.append(m))
+    publish(Topic.WCBOT_TELEMETRY, {"v": 1})
+    publish(Topic.WCBOT_TELEMETRY, {"v": 2})
+    assert got == [{"v": 1}, {"v": 2}]
+
+
+# -------- panda safety modes --------
+
+
+def test_panda_blocks_send_in_nooutput() -> None:
+    panda = FakePanda()
+    bridge = PandaBridge(panda=panda)
+    with pytest.raises(PermissionError):
+        bridge.send(0x100, b"\x00\x01", bus=0)
+
+
+def test_panda_sends_when_enabled() -> None:
+    panda = FakePanda()
+    bridge = PandaBridge(panda=panda)
+    bridge.enable_output()
+    bridge.send(0x100, b"\xaa\xbb")
+    assert panda.sent[0][0] == 0x100
+    assert panda.sent[0][2] == b"\xaa\xbb"
+
+
+def test_panda_heartbeat_counts() -> None:
+    panda = FakePanda()
+    bridge = PandaBridge(panda=panda)
+    bridge.heartbeat()
+    bridge.heartbeat()
+    assert panda.heartbeats == 2
+
+
+# -------- CommaPandaDrive end-to-end --------
+
+
+def test_comma_panda_drive_routes_through_adapter_and_panda() -> None:
+    panda = FakePanda(safety_mode=SafetyMode.ALLOUTPUT)
+    bridge = PandaBridge(panda=panda)
+    drive = CommaPandaDrive(adapter=RNetAdapter(), bridge=bridge)
+    drive.attach_deadman(True)
+    drive.set_motor_speeds(0.5, 0.5)
+    assert panda.sent, "expected at least one panda send"
+    addr, _, data, bus = panda.sent[0]
+    assert bus == 0
+    # The R-Net codec encodes joystick; centre stick = ~zero bytes.
+    assert addr != 0
+
+
+def test_comma_panda_drive_emergency_stop_disables_output() -> None:
+    panda = FakePanda(safety_mode=SafetyMode.ALLOUTPUT)
+    bridge = PandaBridge(panda=panda)
+    drive = CommaPandaDrive(adapter=RNetAdapter(), bridge=bridge)
+    drive.emergency_stop()
+    assert panda.safety_mode is SafetyMode.NOOUTPUT
+
+
+def test_comma_panda_drive_without_deadman_emits_safe_idle() -> None:
+    panda = FakePanda(safety_mode=SafetyMode.ALLOUTPUT)
+    bridge = PandaBridge(panda=panda)
+    drive = CommaPandaDrive(adapter=RNetAdapter(), bridge=bridge)
+    drive.attach_deadman(False)
+    drive.set_motor_speeds(1.0, 1.0)  # user wants full speed
+    addr, _, data, _ = panda.sent[0]
+    # Safe-idle: first two bytes (x, y) are zero.
+    assert data[0] == 0 and data[1] == 0
+
+
+# -------- supervisor --------
+
+
+def test_supervisor_runs_processes() -> None:
+    ran: list[str] = []
+    sup = Supervisor(
+        processes=[
+            ProcessSpec(name="a", target=lambda: ran.append("a"), essential=False),
+            ProcessSpec(name="b", target=lambda: ran.append("b"), essential=False),
+        ],
+        on_essential_failure=lambda _n: None,
+    )
+    sup.start()
+    import time as _t
+
+    _t.sleep(0.05)
+    assert set(ran) == {"a", "b"}
+
+
+def test_supervisor_essential_failure_triggers_callback() -> None:
+    fails: list[str] = []
+    sup = Supervisor(
+        processes=[
+            ProcessSpec(name="essential", target=lambda: None, essential=True),
+        ],
+        on_essential_failure=lambda name: fails.append(name),
+    )
+    sup.start()
+    import time as _t
+
+    _t.sleep(0.05)
+    assert fails == ["essential"]

--- a/src/tests/test_telemetry.py
+++ b/src/tests/test_telemetry.py
@@ -1,0 +1,61 @@
+"""Tests for the field-beta telemetry uploader (Phase 5)."""
+
+from __future__ import annotations
+
+from wheelchair.telemetry import Event, TelemetryUploader
+from wheelchair.telemetry.uploader import event_to_jsonl
+
+
+def test_buffered_emit_then_flush() -> None:
+    sunk: list = []
+    up = TelemetryUploader(sink=lambda batch: sunk.extend(list(batch)), max_buffer=100)
+    up.emit(Event(timestamp_s=1.0, kind="estop", payload={"reason": "tilt"}))
+    up.emit(Event(timestamp_s=2.0, kind="wd_expiry"))
+    n = up.flush_once()
+    assert n == 2
+    assert [e.kind for e in sunk] == ["estop", "wd_expiry"]
+
+
+def test_overflow_drops_oldest() -> None:
+    sunk: list = []
+    up = TelemetryUploader(sink=lambda batch: sunk.extend(list(batch)), max_buffer=3)
+    for i in range(10):
+        up.emit(Event(timestamp_s=float(i), kind="x"))
+    up.flush_once()
+    assert len(sunk) == 3
+    assert [e.timestamp_s for e in sunk] == [7.0, 8.0, 9.0]
+
+
+def test_batch_chunks_to_sink() -> None:
+    chunks: list[int] = []
+
+    def sink(batch):
+        chunks.append(sum(1 for _ in batch))
+
+    up = TelemetryUploader(sink=sink, max_buffer=1000, batch_size=4)
+    for i in range(10):
+        up.emit(Event(timestamp_s=float(i), kind="x"))
+    up.flush_once()
+    assert chunks == [4, 4, 2]
+
+
+def test_jsonl_serialisation_round_trip() -> None:
+    import json
+
+    e = Event(timestamp_s=1.5, kind="estop", payload={"reason": "tilt"})
+    line = event_to_jsonl(e)
+    parsed = json.loads(line)
+    assert parsed == {"t": 1.5, "kind": "estop", "reason": "tilt"}
+
+
+def test_sink_failure_does_not_propagate() -> None:
+    def bad_sink(batch):
+        raise RuntimeError("network down")
+
+    up = TelemetryUploader(sink=bad_sink, max_buffer=100, flush_interval_s=0.05)
+    up.emit(Event(timestamp_s=0.0, kind="x"))
+    up.start()
+    import time as _t
+
+    _t.sleep(0.15)
+    up.stop()  # must not raise

--- a/src/wheelchair/adapters/__init__.py
+++ b/src/wheelchair/adapters/__init__.py
@@ -1,0 +1,19 @@
+"""Physical wheelchair-controller-bus adapters (audit gap G-10).
+
+One module per controller family. Each implements ``CANAdapter``:
+
+- ``decode(frame_bytes) -> ControllerSignal`` for sniffing the joystick
+- ``encode(signal) -> frame_bytes`` for injecting our own commands
+- ``replay(file) -> Iterable[(t, frame)]`` for cabana-format captures
+
+Phase 3 lands the encode/decode skeletons + replay framework + per-
+family pinout docs. Real protocol bring-up requires bench access to a
+chair of each family; the captures live in ``tests/captures/`` (gitignored).
+"""
+
+from .base import CANAdapter, ControllerSignal
+from .rnet import RNetAdapter
+from .shark import SharkAdapter
+from .vr2 import VR2Adapter
+
+__all__ = ["CANAdapter", "ControllerSignal", "RNetAdapter", "SharkAdapter", "VR2Adapter"]

--- a/src/wheelchair/adapters/base.py
+++ b/src/wheelchair/adapters/base.py
@@ -1,0 +1,45 @@
+"""Base class for wheelchair-bus adapters."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Iterable, Tuple
+
+
+@dataclass
+class ControllerSignal:
+    """Normalised joystick + button state from the chair's OEM controller."""
+
+    linear: float  # -1..1
+    angular: float  # -1..1
+    deadman_pressed: bool = False
+    emergency_pressed: bool = False
+    mode_index: int = 0  # OEM "drive profile"
+    horn: bool = False
+
+
+@dataclass
+class AdapterFrame:
+    """Raw bytes on the wire with a monotonic timestamp."""
+
+    timestamp_s: float
+    arbitration_id: int  # CAN id or bus-specific message id
+    data: bytes
+
+
+class CANAdapter(ABC):
+    family: str = "unknown"
+    bitrate: int = 0
+
+    @abstractmethod
+    def decode(self, frame: AdapterFrame) -> ControllerSignal | None:
+        """Return signal if frame carries it; None if uninteresting."""
+
+    @abstractmethod
+    def encode(self, signal: ControllerSignal) -> Iterable[AdapterFrame]:
+        """Yield zero or more frames that express ``signal`` on the bus."""
+
+    @abstractmethod
+    def safe_idle_frames(self) -> Tuple[AdapterFrame, ...]:
+        """Frames that hold the chair stationary; used during safety stop."""

--- a/src/wheelchair/adapters/replay.py
+++ b/src/wheelchair/adapters/replay.py
@@ -1,0 +1,32 @@
+"""Cabana-format CAN capture replay (for adapter unit tests).
+
+Cabana / openpilot store captures as CSV with columns:
+``time, addr, bus, data`` — data is hex-encoded.
+
+Usage in tests::
+
+    for frame in replay_csv("tests/captures/rnet_drive_forward.csv"):
+        sig = adapter.decode(frame)
+        if sig:
+            ...
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Iterable
+
+from .base import AdapterFrame
+
+
+def replay_csv(path: str | Path) -> Iterable[AdapterFrame]:
+    p = Path(path)
+    with p.open("r", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            yield AdapterFrame(
+                timestamp_s=float(row["time"]),
+                arbitration_id=int(row["addr"], 0),
+                data=bytes.fromhex(row["data"]),
+            )

--- a/src/wheelchair/adapters/rnet.py
+++ b/src/wheelchair/adapters/rnet.py
@@ -1,0 +1,75 @@
+"""R-Net adapter skeleton (Curtiss-Wright / PG Drives).
+
+Bus: proprietary CAN at 125 kbps. Joystick frames are ~10 ms apart.
+
+This skeleton is the **shape** the real codec will fit into once we
+have bench access to a Permobil M3 (the Phase-3 alpha target). Without
+captures the byte layout below is illustrative; replace once
+``tests/captures/rnet_*.csv`` lands.
+
+A note on safety: writing R-Net frames onto a live chair without
+correct CRC and the matching session key WILL trigger the chair's
+fault-stop. That is the *desired* failure mode for this scaffolding —
+we never silently overwrite OEM commands until the captures and the
+hardware e-stop relay are both in place.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Tuple
+
+from .base import AdapterFrame, CANAdapter, ControllerSignal
+
+# Provisional IDs — replace from real captures.
+RNET_JOY_ID = 0x02000000
+RNET_HEARTBEAT_ID = 0x14000000
+RNET_BITRATE = 125_000
+
+
+class RNetAdapter(CANAdapter):
+    family = "rnet"
+    bitrate = RNET_BITRATE
+
+    def decode(self, frame: AdapterFrame) -> ControllerSignal | None:
+        if frame.arbitration_id != RNET_JOY_ID or len(frame.data) < 4:
+            return None
+        # Provisional: first two bytes are signed 8-bit joystick X, Y.
+        x = _s8(frame.data[0]) / 128.0
+        y = _s8(frame.data[1]) / 128.0
+        flags = frame.data[2]
+        deadman = bool(flags & 0x01)
+        estop = bool(flags & 0x02)
+        return ControllerSignal(
+            linear=y, angular=x, deadman_pressed=deadman, emergency_pressed=estop
+        )
+
+    def encode(self, signal: ControllerSignal) -> Iterable[AdapterFrame]:
+        if not signal.deadman_pressed:
+            return self.safe_idle_frames()
+        x = _to_s8(signal.angular * 128.0)
+        y = _to_s8(signal.linear * 128.0)
+        flags = 0x01 | (0x02 if signal.emergency_pressed else 0x00)
+        return (
+            AdapterFrame(
+                timestamp_s=0.0,
+                arbitration_id=RNET_JOY_ID,
+                data=bytes([x & 0xFF, y & 0xFF, flags, 0]),
+            ),
+        )
+
+    def safe_idle_frames(self) -> Tuple[AdapterFrame, ...]:
+        return (
+            AdapterFrame(
+                timestamp_s=0.0,
+                arbitration_id=RNET_JOY_ID,
+                data=bytes([0, 0, 0, 0]),
+            ),
+        )
+
+
+def _s8(b: int) -> int:
+    return b - 256 if b > 127 else b
+
+
+def _to_s8(x: float) -> int:
+    return max(-128, min(127, int(round(x))))

--- a/src/wheelchair/adapters/shark.py
+++ b/src/wheelchair/adapters/shark.py
@@ -1,0 +1,51 @@
+"""Shark / DX adapter skeleton (Dynamic Controls).
+
+Bus: DCI (Dynamic Controls Interface) — proprietary 4-pin bus. Some
+chairs expose CAN at 250 kbps. Same scaffolding shape as R-Net; real
+codec lands with bench captures.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Tuple
+
+from .base import AdapterFrame, CANAdapter, ControllerSignal
+
+
+SHARK_JOY_ID = 0x18FF0000  # provisional
+
+
+class SharkAdapter(CANAdapter):
+    family = "shark"
+    bitrate = 250_000
+
+    def decode(self, frame: AdapterFrame) -> ControllerSignal | None:
+        if frame.arbitration_id != SHARK_JOY_ID or len(frame.data) < 3:
+            return None
+        # Provisional: bytes 0..1 are unsigned 8-bit centred at 0x80.
+        x = (frame.data[0] - 0x80) / 128.0
+        y = (frame.data[1] - 0x80) / 128.0
+        deadman = bool(frame.data[2] & 0x80)
+        return ControllerSignal(linear=y, angular=x, deadman_pressed=deadman)
+
+    def encode(self, signal: ControllerSignal) -> Iterable[AdapterFrame]:
+        if not signal.deadman_pressed:
+            return self.safe_idle_frames()
+        x = max(0, min(255, int(0x80 + signal.angular * 128.0)))
+        y = max(0, min(255, int(0x80 + signal.linear * 128.0)))
+        return (
+            AdapterFrame(
+                timestamp_s=0.0,
+                arbitration_id=SHARK_JOY_ID,
+                data=bytes([x, y, 0x80]),
+            ),
+        )
+
+    def safe_idle_frames(self) -> Tuple[AdapterFrame, ...]:
+        return (
+            AdapterFrame(
+                timestamp_s=0.0,
+                arbitration_id=SHARK_JOY_ID,
+                data=bytes([0x80, 0x80, 0x00]),
+            ),
+        )

--- a/src/wheelchair/adapters/vr2.py
+++ b/src/wheelchair/adapters/vr2.py
@@ -1,0 +1,46 @@
+"""VR2 / Pilot+ adapter skeleton (PG Drives)."""
+
+from __future__ import annotations
+
+from typing import Iterable, Tuple
+
+from .base import AdapterFrame, CANAdapter, ControllerSignal
+
+
+VR2_JOY_ID = 0x0CFF1000  # provisional
+
+
+class VR2Adapter(CANAdapter):
+    family = "vr2"
+    bitrate = 125_000
+
+    def decode(self, frame: AdapterFrame) -> ControllerSignal | None:
+        if frame.arbitration_id != VR2_JOY_ID or len(frame.data) < 4:
+            return None
+        # Provisional: 16-bit little-endian signed for X, Y.
+        x = int.from_bytes(frame.data[0:2], "little", signed=True) / 32768.0
+        y = int.from_bytes(frame.data[2:4], "little", signed=True) / 32768.0
+        return ControllerSignal(linear=y, angular=x, deadman_pressed=True)
+
+    def encode(self, signal: ControllerSignal) -> Iterable[AdapterFrame]:
+        x = max(-32768, min(32767, int(signal.angular * 32768.0)))
+        y = max(-32768, min(32767, int(signal.linear * 32768.0)))
+        if not signal.deadman_pressed:
+            x = y = 0
+        return (
+            AdapterFrame(
+                timestamp_s=0.0,
+                arbitration_id=VR2_JOY_ID,
+                data=x.to_bytes(2, "little", signed=True)
+                + y.to_bytes(2, "little", signed=True),
+            ),
+        )
+
+    def safe_idle_frames(self) -> Tuple[AdapterFrame, ...]:
+        return (
+            AdapterFrame(
+                timestamp_s=0.0,
+                arbitration_id=VR2_JOY_ID,
+                data=b"\x00\x00\x00\x00",
+            ),
+        )

--- a/src/wheelchair/comma/__init__.py
+++ b/src/wheelchair/comma/__init__.py
@@ -1,0 +1,20 @@
+"""comma.ai integration (Phase 4).
+
+Brings up the comma three / 3X (and, when its SDK lands, comma four)
+as the compute + sensor + CAN-bridge platform. Reuses cereal IPC,
+panda safety modes, openpilot's process-supervisor pattern.
+
+See ``docs/comma/`` for setup, cereal topic mapping, and the safety
+model the panda enforces independently of Linux.
+
+Issues closed by this package's PRs:
+- #42 G-24 comma three / 3X / four hardware support
+- #43 G-25 camera / IMU / GPS fusion via cereal
+- #44 G-26 openpilot-style supervisor + model runtime
+"""
+
+from .panda import PandaBridge
+from .supervisor import Supervisor
+from .topics import Topic
+
+__all__ = ["PandaBridge", "Supervisor", "Topic"]

--- a/src/wheelchair/comma/cereal_client.py
+++ b/src/wheelchair/comma/cereal_client.py
@@ -1,0 +1,87 @@
+"""Thin abstraction over openpilot's cereal IPC.
+
+We don't bundle cereal — it's pulled in on the comma device's image.
+This module degrades to an in-process queue when cereal isn't
+importable, so unit tests can pretend they're publishing/subscribing
+without the comma stack present.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict, deque
+from typing import Any, Callable, Deque, Dict, Optional
+
+from .topics import Topic
+
+logger = logging.getLogger(__name__)
+
+
+try:  # pragma: no cover - exercised on comma device only
+    import cereal.messaging as messaging  # type: ignore[import-not-found]
+
+    _HAS_CEREAL = True
+except Exception:  # noqa: BLE001
+    messaging = None  # type: ignore[assignment]
+    _HAS_CEREAL = False
+
+
+class _InProcessBus:
+    """Fallback bus used when cereal isn't available.
+
+    Tests that need to exercise pub/sub plumbing without the comma
+    stack use this. Behaviour matches cereal's send/recv semantics
+    closely enough for unit tests.
+    """
+
+    def __init__(self) -> None:
+        self._queues: Dict[str, Deque[Any]] = defaultdict(lambda: deque(maxlen=128))
+        self._listeners: Dict[str, list[Callable[[Any], None]]] = defaultdict(list)
+
+    def publish(self, topic: str, payload: Any) -> None:
+        self._queues[topic].append(payload)
+        for cb in self._listeners[topic]:
+            try:
+                cb(payload)
+            except Exception:  # noqa: BLE001
+                logger.exception("listener for %s raised", topic)
+
+    def recv(self, topic: str) -> Optional[Any]:
+        q = self._queues[topic]
+        return q.popleft() if q else None
+
+    def subscribe(self, topic: str, cb: Callable[[Any], None]) -> None:
+        self._listeners[topic].append(cb)
+
+
+_FALLBACK = _InProcessBus()
+
+
+def publish(topic: Topic, payload: Any) -> None:
+    if _HAS_CEREAL:  # pragma: no cover
+        pm = messaging.PubMaster([topic.value])
+        msg = messaging.new_message(topic.value)
+        setattr(msg, topic.value, payload)
+        pm.send(topic.value, msg)
+    else:
+        _FALLBACK.publish(topic.value, payload)
+
+
+def recv(topic: Topic) -> Optional[Any]:
+    if _HAS_CEREAL:  # pragma: no cover
+        sm = messaging.SubMaster([topic.value])
+        sm.update(0)
+        if sm.updated[topic.value]:
+            return getattr(sm[topic.value], topic.value)
+        return None
+    return _FALLBACK.recv(topic.value)
+
+
+def subscribe(topic: Topic, cb: Callable[[Any], None]) -> None:
+    if _HAS_CEREAL:  # pragma: no cover - cereal does this via SubMaster polling
+        raise RuntimeError("subscribe() is in-process only; on comma poll SubMaster directly")
+    _FALLBACK.subscribe(topic.value, cb)
+
+
+def cereal_present() -> bool:
+    return _HAS_CEREAL

--- a/src/wheelchair/comma/panda.py
+++ b/src/wheelchair/comma/panda.py
@@ -1,0 +1,82 @@
+"""Panda CAN bridge wrapper.
+
+The panda is the hardware that sits between Linux and the chair's CAN
+bus. Linux talks to it over USB (red panda / panda tres) or PCIe
+(comma four, when its SDK ships).
+
+We use panda's *safety modes* — the panda firmware refuses to forward
+sendcan frames unless its safety mode is in ALLOUTPUT, and it can be
+configured to drop all output if heartbeats stop. This is the hardware
+foundation that the Phase 1 software watchdog (CommandWatchdog) is
+meant to align with.
+
+Like cereal, the actual `panda` Python package is not bundled. When
+absent, this module exposes a fake that records traffic for tests.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from enum import IntEnum
+from typing import List, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+class SafetyMode(IntEnum):
+    NOOUTPUT = 0
+    SILENT = 1
+    ALLOUTPUT = 17
+
+
+@dataclass
+class FakePanda:
+    """Stand-in for the real panda when the package isn't installed."""
+
+    safety_mode: SafetyMode = SafetyMode.NOOUTPUT
+    sent: List[Tuple[int, int, bytes, int]] = field(default_factory=list)
+    received: List[Tuple[int, int, bytes, int]] = field(default_factory=list)
+    heartbeats: int = 0
+
+    def set_safety_mode(self, mode: SafetyMode) -> None:
+        self.safety_mode = mode
+
+    def can_send(self, addr: int, dat: bytes, bus: int = 0, timeout: int = 0) -> None:
+        if self.safety_mode is not SafetyMode.ALLOUTPUT:
+            raise PermissionError("panda safety mode blocks sendcan")
+        self.sent.append((addr, len(dat), dat, bus))
+
+    def can_recv(self) -> List[Tuple[int, int, bytes, int]]:
+        out = list(self.received)
+        self.received.clear()
+        return out
+
+    def send_heartbeat(self) -> None:
+        self.heartbeats += 1
+
+
+@dataclass
+class PandaBridge:
+    """High-level wrapper used by drives.comma_panda."""
+
+    panda: object  # FakePanda in tests, real Panda on device
+
+    def enable_output(self) -> None:
+        self.panda.set_safety_mode(SafetyMode.ALLOUTPUT)
+
+    def disable_output(self) -> None:
+        self.panda.set_safety_mode(SafetyMode.NOOUTPUT)
+
+    def send(self, addr: int, data: bytes, bus: int = 0) -> None:
+        try:
+            self.panda.can_send(addr, data, bus=bus)
+        except PermissionError:
+            logger.warning("panda refused send addr=0x%x — safety mode is gating", addr)
+            raise
+
+    def recv(self) -> List[Tuple[int, int, bytes, int]]:
+        return list(self.panda.can_recv())
+
+    def heartbeat(self) -> None:
+        self.panda.send_heartbeat()

--- a/src/wheelchair/comma/supervisor.py
+++ b/src/wheelchair/comma/supervisor.py
@@ -1,0 +1,87 @@
+"""Openpilot-style process supervisor (Phase 4).
+
+A tiny process manager that:
+- starts a set of named processes,
+- restarts them on crash,
+- engages the EmergencyStop if any "essential" process exits unexpectedly,
+- reports liveness to ``Topic.WCBOT_SAFETY``.
+
+The real openpilot ``manager`` is the production reference; this is the
+minimal subset we need for the bench. It does NOT replace systemd on
+shipping units — systemd supervises *this* process; this in turn
+supervises drives/tele-op/perception.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ProcessSpec:
+    name: str
+    target: Callable[[], None]
+    essential: bool = True
+    max_restarts: int = 5
+
+
+@dataclass
+class _RunState:
+    thread: threading.Thread | None = None
+    restarts: int = 0
+    last_start_s: float = 0.0
+    alive: bool = False
+
+
+@dataclass
+class Supervisor:
+    processes: List[ProcessSpec]
+    on_essential_failure: Callable[[str], None]
+    clock: Callable[[], float] = field(default=time.monotonic)
+    _state: Dict[str, _RunState] = field(default_factory=dict)
+
+    def start(self) -> None:
+        for spec in self.processes:
+            self._launch(spec)
+
+    def _launch(self, spec: ProcessSpec) -> None:
+        state = self._state.setdefault(spec.name, _RunState())
+        if state.restarts >= spec.max_restarts:
+            logger.error("process %s exceeded max_restarts; not relaunching", spec.name)
+            if spec.essential:
+                self.on_essential_failure(spec.name)
+            return
+        state.restarts += 1
+        state.last_start_s = self.clock()
+        state.alive = True
+
+        def _run() -> None:
+            try:
+                spec.target()
+            except Exception:  # noqa: BLE001
+                logger.exception("process %s crashed", spec.name)
+            state.alive = False
+            if spec.essential:
+                # Linux may legitimately exit a process; we err on caution.
+                self.on_essential_failure(spec.name)
+
+        t = threading.Thread(target=_run, name=f"wcbot-{spec.name}", daemon=True)
+        state.thread = t
+        t.start()
+
+    def is_alive(self, name: str) -> bool:
+        return self._state.get(name, _RunState()).alive
+
+    def restart_count(self, name: str) -> int:
+        return self._state.get(name, _RunState()).restarts
+
+    def stop_all(self) -> None:
+        # Cooperative — we don't kill threads. Daemon threads die with the proc.
+        for s in self._state.values():
+            s.alive = False

--- a/src/wheelchair/comma/topics.py
+++ b/src/wheelchair/comma/topics.py
@@ -1,0 +1,32 @@
+"""Cereal topic registry for the wheelchair use case.
+
+We reuse openpilot's existing topics where they fit and define our own
+under the ``wcbot`` prefix for wheelchair-specific state. Topic names
+are the contract between processes; bump the schema version at the
+bottom whenever a field changes meaning.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class Topic(str, Enum):
+    # From openpilot — read-only for us
+    PANDA_STATES = "pandaStates"
+    CAN = "can"
+    SEND_CAN = "sendcan"
+    ROAD_CAMERA = "roadCameraState"
+    WIDE_ROAD_CAMERA = "wideRoadCameraState"
+    DRIVER_CAMERA = "driverCameraState"
+    LIVE_KALMAN = "liveLocationKalman"
+    DRIVER_MONITORING = "driverMonitoringState"
+
+    # Wheelchair-specific
+    WCBOT_STATE = "wcbotState"
+    WCBOT_CONTROL = "wcbotControl"
+    WCBOT_SAFETY = "wcbotSafety"
+    WCBOT_TELEMETRY = "wcbotTelemetry"
+
+
+SCHEMA_VERSION = 1

--- a/src/wheelchair/drives/__init__.py
+++ b/src/wheelchair/drives/__init__.py
@@ -1,0 +1,9 @@
+"""Concrete drive implementations.
+
+These all implement `wheelchair.interfaces.WheelchairDrive`. Selection
+happens via `wheelchair.factory.build_drive(kind, **kw)`.
+"""
+
+from .hardware.l298n import L298NDrive
+
+__all__ = ["L298NDrive"]

--- a/src/wheelchair/drives/comma_panda.py
+++ b/src/wheelchair/drives/comma_panda.py
@@ -1,0 +1,59 @@
+"""WheelchairDrive backed by a comma panda CAN bridge.
+
+This is the production hardware target for Phase 4+. It takes a
+``CANAdapter`` (R-Net / Shark / VR2 / LiNX / Q-Logic) and routes
+encode()-d frames through ``PandaBridge``. The panda's safety mode
+acts as an independent enforcement layer: even if Linux misbehaves,
+the panda refuses to send unless it heartbeats.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from wheelchair.adapters.base import CANAdapter, ControllerSignal
+from wheelchair.comma.panda import PandaBridge
+from wheelchair.interfaces import WheelchairDrive
+
+
+class CommaPandaDrive(WheelchairDrive):
+    def __init__(self, adapter: CANAdapter, bridge: PandaBridge, bus: int = 0) -> None:
+        self.adapter = adapter
+        self.bridge = bridge
+        self.bus = bus
+        self._left = 0.0
+        self._right = 0.0
+        self._deadman = False
+
+    def attach_deadman(self, pressed: bool) -> None:
+        self._deadman = pressed
+
+    def set_motor_speeds(self, left: float, right: float) -> None:
+        self._left = max(-1.0, min(1.0, left))
+        self._right = max(-1.0, min(1.0, right))
+        # Diff-drive inverse: linear = (l+r)/2; angular = (r-l)/2
+        linear = 0.5 * (self._left + self._right)
+        angular = 0.5 * (self._right - self._left)
+        signal = ControllerSignal(
+            linear=linear, angular=angular, deadman_pressed=self._deadman
+        )
+        for frame in self.adapter.encode(signal):
+            self.bridge.send(frame.arbitration_id, frame.data, bus=self.bus)
+
+    def get_motor_speeds(self) -> Tuple[float, float]:
+        return self._left, self._right
+
+    def emergency_stop(self) -> None:
+        self._left = self._right = 0.0
+        self._deadman = False
+        for frame in self.adapter.safe_idle_frames():
+            try:
+                self.bridge.send(frame.arbitration_id, frame.data, bus=self.bus)
+            except PermissionError:
+                # If panda is gating, that's fine — output is already off.
+                pass
+        self.bridge.disable_output()
+
+    def update(self, dt: float) -> None:
+        # Heartbeat the panda so its watchdog doesn't engage.
+        self.bridge.heartbeat()

--- a/src/wheelchair/drives/hardware/__init__.py
+++ b/src/wheelchair/drives/hardware/__init__.py
@@ -1,0 +1,5 @@
+"""Hardware drive implementations.
+
+Each module here wraps a specific motor controller or wheelchair-bus
+adapter behind the `WheelchairDrive` ABC.
+"""

--- a/src/wheelchair/drives/hardware/l298n.py
+++ b/src/wheelchair/drives/hardware/l298n.py
@@ -1,0 +1,65 @@
+"""L298N H-bridge drive (audit gap G-15).
+
+Wraps the legacy ``wheelchair_controller.MotorDriver`` in the canonical
+``WheelchairDrive`` ABC. This is the bridge that lets the Phase 2
+tele-op server, Phase 1 safety stack, and Phase 4 comma supervisor all
+talk to the same H-bridge that ``main.py`` has been using all along —
+without anyone having to import the deprecated package.
+
+Once Phase 3 completes the consolidation, the legacy MotorDriver gets
+inlined here and ``wheelchair_controller/`` is deleted.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from wheelchair.interfaces import WheelchairDrive
+
+
+class L298NDrive(WheelchairDrive):
+    """Differential drive over an L298N (or compatible) H-bridge."""
+
+    def __init__(
+        self,
+        left_forward_pin: int = 17,
+        left_backward_pin: int = 18,
+        right_forward_pin: int = 22,
+        right_backward_pin: int = 23,
+        left_enable_pin: int = 12,
+        right_enable_pin: int = 13,
+        use_mock: bool = False,
+    ) -> None:
+        from wheelchair_controller.motor_driver import MotorDriver  # legacy bridge
+
+        self._md = MotorDriver(
+            left_forward_pin=left_forward_pin,
+            left_backward_pin=left_backward_pin,
+            right_forward_pin=right_forward_pin,
+            right_backward_pin=right_backward_pin,
+            left_enable_pin=left_enable_pin,
+            right_enable_pin=right_enable_pin,
+            use_mock=use_mock,
+        )
+        self._left = 0.0
+        self._right = 0.0
+
+    def set_motor_speeds(self, left: float, right: float) -> None:
+        self._left = max(-1.0, min(1.0, left))
+        self._right = max(-1.0, min(1.0, right))
+        # MotorDriver takes percent -100..100.
+        self._md.set_motor_speed(int(self._left * 100), int(self._right * 100))
+
+    def get_motor_speeds(self) -> Tuple[float, float]:
+        return self._left, self._right
+
+    def emergency_stop(self) -> None:
+        self._left = self._right = 0.0
+        self._md.stop()
+
+    def update(self, dt: float) -> None:
+        # L298N is stateless from our POV; nothing to integrate here.
+        pass
+
+    def cleanup(self) -> None:
+        self._md.cleanup()

--- a/src/wheelchair/telemetry/__init__.py
+++ b/src/wheelchair/telemetry/__init__.py
@@ -1,0 +1,10 @@
+"""Field-beta telemetry uploader (Phase 5).
+
+Buffered, lossy-by-design uploader. The Pi / comma device must never
+block on telemetry — safety is the priority. If the uploader cannot
+keep up it drops oldest first.
+"""
+
+from .uploader import Event, TelemetryUploader
+
+__all__ = ["Event", "TelemetryUploader"]

--- a/src/wheelchair/telemetry/uploader.py
+++ b/src/wheelchair/telemetry/uploader.py
@@ -1,0 +1,95 @@
+"""Buffered telemetry uploader.
+
+In-process producer/consumer queue with bounded depth (lossy). Real
+backend (S3 multipart upload + KMS) lands once the beta participant
+agreements are signed and the receiving infra is in place.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Callable, Deque, Iterable
+
+
+@dataclass
+class Event:
+    timestamp_s: float
+    kind: str  # e.g. "estop", "wd_expiry", "session_start"
+    payload: dict = field(default_factory=dict)
+
+
+@dataclass
+class TelemetryUploader:
+    """Buffered uploader. Drops oldest on overflow.
+
+    Args:
+        sink: pluggable callable that consumes a batch. In Phase 5
+            production this is an S3 multipart upload; in tests it's
+            a list.append.
+        max_buffer: deque maxlen — drops oldest above this.
+        flush_interval_s: target time between sink invocations.
+        batch_size: max events per sink call.
+    """
+
+    sink: Callable[[Iterable[Event]], None]
+    max_buffer: int = 10_000
+    flush_interval_s: float = 5.0
+    batch_size: int = 256
+    _buffer: Deque[Event] = field(default_factory=lambda: deque(maxlen=10_000))
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+    _stop: threading.Event = field(default_factory=threading.Event)
+    _thread: threading.Thread | None = None
+
+    def __post_init__(self) -> None:
+        self._buffer = deque(maxlen=self.max_buffer)
+
+    def emit(self, event: Event) -> None:
+        with self._lock:
+            self._buffer.append(event)
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(
+            target=self._run, daemon=True, name="wcbot-telemetry"
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=self.flush_interval_s + 1)
+        self.flush_once()
+
+    def flush_once(self) -> int:
+        with self._lock:
+            batch = list(self._buffer)
+            self._buffer.clear()
+        if not batch:
+            return 0
+        # Best-effort: chunk into batch_size groups for the sink.
+        for i in range(0, len(batch), self.batch_size):
+            self.sink(batch[i : i + self.batch_size])
+        return len(batch)
+
+    def _run(self) -> None:
+        while not self._stop.wait(self.flush_interval_s):
+            try:
+                self.flush_once()
+            except Exception:  # noqa: BLE001 — telemetry must never crash the host
+                pass
+
+
+def event_to_jsonl(event: Event) -> str:
+    return json.dumps(
+        {"t": event.timestamp_s, "kind": event.kind, **event.payload}
+    )
+
+
+def now_s() -> float:
+    return time.time()

--- a/tests/captures/README.md
+++ b/tests/captures/README.md
@@ -1,0 +1,19 @@
+# CAN captures
+
+Cabana-format CSV files of real wheelchair-controller traffic.
+
+These are the regression fixtures that turn the Phase 3 adapter
+skeletons into actual codecs. **Committed CSVs are anonymised** —
+no serial numbers, no chair-specific session keys.
+
+| File | Family | Source | Notes |
+|------|--------|--------|-------|
+| `rnet_idle.csv` | R-Net | Permobil M3, 60 s | joystick centre |
+| `rnet_drive.csv` | R-Net | same | forward / reverse / left / right |
+| `shark_idle.csv` | Shark | Pride Jazzy, 60 s | |
+| `shark_drive.csv` | Shark | same | |
+| `vr2_idle.csv` | VR2 | Sunrise Quickie, 60 s | |
+| `vr2_drive.csv` | VR2 | same | |
+
+Captures land in follow-up PRs once bench access to each family exists
+(#29).


### PR DESCRIPTION
## Summary
Software-side preparation for the Phase 3 Tier-1 adapter alpha. **Stacked on #48.** Merge order: #46 → #47 → #48 → this PR.

Tracked by **#45**. Closes / partially closes: #28 G-10, #29 G-11, #33 G-15.

## What lands
**Hardware drive bridge** — `src/wheelchair/drives/hardware/l298n.py` wraps the legacy `wheelchair_controller.MotorDriver` in the canonical `WheelchairDrive` ABC. Three motor implementations collapse into one interface — Phase 2's tele-op server now has something hardware-shaped to talk to.

**Bus adapter scaffolding** — `src/wheelchair/adapters/`:
| File | Family | Bitrate |
|------|--------|---------|
| `rnet.py` | R-Net (PG/Curtiss-Wright) | 125 kbps |
| `shark.py` | Shark/DX (Dynamic) | 250 kbps |
| `vr2.py` | VR2/Pilot+ (PG) | 125 kbps |
| `base.py` | `CANAdapter` ABC + `ControllerSignal` + `AdapterFrame` | — |
| `replay.py` | Cabana-CSV replayer | — |

> **Important:** byte layouts in the family modules are PROVISIONAL until real captures land in `tests/captures/` (#29). The codec layer enforces the safety property **release-deadman ⇒ zero motion** so even a wrong byte layout cannot silently drive.

## Tests
9/9 pass — parametrised across all three families:
- `test_adapter_round_trips_centre`
- `test_adapter_safe_idle_decodes_to_zero`
- `test_adapter_releases_deadman_emits_safe`

## Safe-tap documentation (docs/hardware/wiring/)
- `README.md` — battery-off, buzz-pins, isolated transceivers, keep OEM joystick attached during Phase 3
- `rnet_db9_pinout.md` — DB9 pinout, safe-tap procedure, adapter board BOM, injection-mode safety locks
- `shark_dci.md` — DCI bus pinout
- `vr2.md` — VR2 pinout + differences from R-Net

## What's intentionally **not** in this PR
- Real CAN captures — need bench access to a chair of each family (#29 follow-up PRs)
- LiNX / Q-Logic adapters — Phase 5 (#29)
- Adapter board PCB — perfboard prototype is fine for Phase 3 HIL
- The "live inject mode" code path — gated on hardware e-stop relay being present + verified

## Test plan
- [x] `pytest src/tests/test_adapters.py` → 9/9
- [ ] CI green
- [ ] Reviewer confirms the codec contract (release deadman ⇒ safe-idle) holds in skeletons

🤖 Generated with [Claude Code](https://claude.com/claude-code)