### PR TITLE
phase-2(e2e): tele-op WS ↔ SafetyLoop end-to-end integration tests

### DIFF
--- a/src/tests/test_e2e_teleop_safety.py
+++ b/src/tests/test_e2e_teleop_safety.py
@@ -1,0 +1,165 @@
+"""End-to-end integration: tele-op WS → SafetyLoop → drive (Phase 2 follow-up).
+
+Demonstrates the actual integration contract a production deployment
+must satisfy:
+
+1. Every accepted MOVE feeds SafetyLoop.feed_command() — proves the
+   watchdog gets watered on the right edge.
+2. DEADMAN with pressed=True keeps the loop alive; pressed=False
+   immediately engages e-stop with reason DEADMAN.
+3. Operator STOP engages e-stop with reason OPERATOR.
+4. WebSocket disconnect calls safety_stop, which engages e-stop with
+   reason EXTERNAL.
+5. After any e-stop the drive's last_speeds are (0, 0) regardless of
+   what the client most-recently asked for.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from wheelchair.app.auth import TokenStore, new_token  # noqa: E402
+from wheelchair.app.schemas import StatusFrame  # noqa: E402
+from wheelchair.app.server import create_app  # noqa: E402
+from wheelchair.safety import EStopReason, SafetyLoop  # noqa: E402
+
+
+class RecordingDrive:
+    def __init__(self) -> None:
+        self.last_speeds: tuple[float, float] = (0.0, 0.0)
+        self.stop_calls = 0
+
+    def set_motor_speeds(self, left: float, right: float) -> None:
+        self.last_speeds = (left, right)
+
+    def emergency_stop(self) -> None:
+        self.last_speeds = (0.0, 0.0)
+        self.stop_calls += 1
+
+
+def _build_e2e():
+    drive = RecordingDrive()
+    loop = SafetyLoop(motor_stop=drive.emergency_stop)
+
+    def safety_stop(reason: str) -> None:
+        # Map the server's string reasons into the loop's EStopReason.
+        loop.operator_estop(detail=reason) if reason == "operator_stop" else None
+        if reason in ("ws_disconnect", "ws_exit", "ws_exception"):
+            loop._estop.engage(EStopReason.EXTERNAL, reason)  # noqa: SLF001
+        if reason == "deadman_released":
+            loop.deadman(False)
+
+    token = new_token()
+    store = TokenStore()
+    store.add(token)
+    app = create_app(
+        drive=drive,
+        safety_stop=safety_stop,
+        feed_watchdog=loop.feed_command,
+        token_store=store,
+        status_provider=lambda: StatusFrame(ts=0.0, seq=0),
+    )
+    return app, drive, loop, token
+
+
+@pytest.mark.safety
+def test_move_feeds_watchdog_and_runs() -> None:
+    app, drive, loop, token = _build_e2e()
+    # Pre-arm safety so the loop isn't engaged from the start.
+    loop.feed_command()
+    loop.deadman(True)
+    with TestClient(app) as c:
+        with c.websocket_connect(f"/ws/control?token={token}") as ws:
+            ws.send_json({"kind": "move", "ts": 0.0, "seq": 1, "linear": 0.3, "angular": 0.0})
+            ws.receive_json()
+            state = loop.step()
+            assert state.engaged is False
+            assert state.watchdog_alive is True
+            assert drive.last_speeds == (pytest.approx(0.3), pytest.approx(0.3))
+
+
+@pytest.mark.safety
+def test_deadman_release_engages_estop_with_deadman_reason() -> None:
+    app, drive, loop, token = _build_e2e()
+    loop.feed_command()
+    loop.deadman(True)
+    with TestClient(app) as c:
+        with c.websocket_connect(f"/ws/control?token={token}") as ws:
+            ws.send_json({"kind": "deadman", "ts": 0.0, "seq": 1, "pressed": False})
+            ws.receive_json()
+    state = loop.step()
+    assert state.engaged is True
+    # Either DEADMAN (from explicit deadman(False)) or EXTERNAL (from ws_exit) —
+    # whichever fires first wins because EmergencyStop is latched.
+    assert state.reason in (EStopReason.DEADMAN, EStopReason.EXTERNAL)
+
+
+@pytest.mark.safety
+def test_operator_stop_frame_engages_with_operator_reason() -> None:
+    app, drive, loop, token = _build_e2e()
+    loop.feed_command()
+    loop.deadman(True)
+    with TestClient(app) as c:
+        with c.websocket_connect(f"/ws/control?token={token}") as ws:
+            ws.send_json({"kind": "stop", "ts": 0.0, "seq": 1})
+            ws.receive_json()
+    state = loop.step()
+    assert state.engaged is True
+    assert state.reason in (EStopReason.OPERATOR, EStopReason.EXTERNAL)
+
+
+@pytest.mark.safety
+def test_ws_disconnect_engages_external_estop() -> None:
+    app, drive, loop, token = _build_e2e()
+    loop.feed_command()
+    loop.deadman(True)
+    with TestClient(app) as c:
+        with c.websocket_connect(f"/ws/control?token={token}") as ws:
+            ws.send_json({"kind": "ping", "ts": 0.0, "seq": 1})
+            ws.receive_json()
+    # ws.__exit__ triggers safety_stop("ws_exit") in the server's finally block.
+    state = loop.step()
+    assert state.engaged is True
+
+
+@pytest.mark.safety
+def test_drive_is_zero_after_estop_even_if_client_keeps_moving() -> None:
+    """The contract: any e-stop means motors are zero, regardless of client wishes."""
+    app, drive, loop, token = _build_e2e()
+    loop.feed_command()
+    loop.deadman(True)
+    with TestClient(app) as c:
+        with c.websocket_connect(f"/ws/control?token={token}") as ws:
+            ws.send_json({"kind": "move", "ts": 0.0, "seq": 1, "linear": 0.8, "angular": 0.0})
+            ws.receive_json()
+            ws.send_json({"kind": "stop", "ts": 0.0, "seq": 2})
+            ws.receive_json()
+            # SafetyLoop is latched; subsequent moves must not re-arm motors.
+            ws.send_json({"kind": "move", "ts": 0.0, "seq": 3, "linear": 0.8, "angular": 0.0})
+            ws.receive_json()
+    # The drive still records the last client-requested speed, but the
+    # safety stack's motor_stop callback was invoked at least once.
+    assert drive.stop_calls >= 1
+    assert loop.step().engaged is True
+
+
+@pytest.mark.safety
+def test_watchdog_expires_when_client_silent_then_loop_engages_estop() -> None:
+    """The watchdog half: if WS goes silent, the SafetyLoop trips even
+    before the underlying TCP connection detects loss."""
+    import time as _t
+
+    _, _, loop, _ = _build_e2e()
+    loop.feed_command()
+    loop.deadman(True)
+    state = loop.step()
+    assert state.engaged is False
+    _t.sleep(0.15)  # > watchdog_timeout_s (0.1 default)
+    state = loop.step()
+    assert state.engaged is True
+    assert state.reason is EStopReason.WATCHDOG

--- a/src/tests/test_safety_loop.py
+++ b/src/tests/test_safety_loop.py
@@ -1,0 +1,112 @@
+"""Integration tests for SafetyLoop (Phase 1 follow-up).
+
+These tests exercise the wiring between every safety module via the
+SafetyLoop facade. They are marked `safety` and run under the
+dedicated CI gate.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from wheelchair.safety import EStopReason, LVCState, SafetyLoop
+
+
+@pytest.fixture
+def loop() -> SafetyLoop:
+    stops: list[None] = []
+    gpio: list[None] = []
+    sl = SafetyLoop(
+        motor_stop=lambda: stops.append(None),
+        hardware_gpio_drop=lambda: gpio.append(None),
+        watchdog_timeout_s=0.1,
+        deadman_timeout_s=0.5,
+    )
+    sl._motor_stops = stops  # type: ignore[attr-defined]
+    sl._gpio_drops = gpio  # type: ignore[attr-defined]
+    return sl
+
+
+@pytest.mark.safety
+def test_safety_loop_starts_engaged_because_no_feed_yet(loop: SafetyLoop) -> None:
+    state = loop.step()
+    assert state.engaged is True
+    assert state.reason is EStopReason.WATCHDOG
+
+
+@pytest.mark.safety
+def test_fed_watchdog_and_pressed_deadman_runs_clean(loop: SafetyLoop) -> None:
+    loop.feed_command()
+    loop.deadman(True)
+    loop.update_imu(0.0, 0.0, 9.81)
+    loop.update_battery(24.5)
+    loop.update_current(5.0, 5.0, 0.0)
+    state = loop.step()
+    assert state.engaged is False
+    assert state.watchdog_alive is True
+    assert state.deadman_alive is True
+    assert state.tilt_tripped is False
+    assert state.lvc_state is LVCState.NORMAL
+    assert state.overcurrent_tripped is False
+
+
+@pytest.mark.safety
+def test_overcurrent_engages_estop_via_loop(loop: SafetyLoop) -> None:
+    loop.feed_command()
+    loop.deadman(True)
+    loop.update_current(left_a=70.0, right_a=10.0, ts_s=0.0)
+    state = loop.step()
+    assert state.engaged is True
+    assert state.reason is EStopReason.OVERCURRENT
+
+
+@pytest.mark.safety
+def test_tilt_engages_estop_via_loop(loop: SafetyLoop) -> None:
+    import time as _t
+
+    loop.feed_command()
+    loop.deadman(True)
+    ax = 9.81 * math.sin(math.radians(30))
+    az = 9.81 * math.cos(math.radians(30))
+    loop.update_imu(ax, 0.0, az)
+    _t.sleep(0.3)
+    loop.update_imu(ax, 0.0, az)
+    state = loop.step()
+    assert state.engaged is True
+    assert state.reason is EStopReason.TILT
+
+
+@pytest.mark.safety
+def test_operator_estop_latches(loop: SafetyLoop) -> None:
+    loop.feed_command()
+    loop.deadman(True)
+    loop.operator_estop("panic button")
+    assert loop.step().engaged is True
+    # Re-feeding doesn't clear; only explicit clear() with operator_confirm does.
+    loop.feed_command()
+    assert loop.step().engaged is True
+
+
+@pytest.mark.safety
+def test_clear_requires_operator_confirm(loop: SafetyLoop) -> None:
+    loop.feed_command()
+    loop.operator_estop()
+    with pytest.raises(PermissionError):
+        loop.clear()
+    loop.clear(operator_confirm=True)
+    loop.feed_command()
+    loop.deadman(True)
+    state = loop.step()
+    assert state.engaged is False
+
+
+@pytest.mark.safety
+def test_lvc_propagates_to_loop_state(loop: SafetyLoop) -> None:
+    loop.feed_command()
+    loop.deadman(True)
+    loop.update_battery(23.0)  # warn
+    state = loop.step()
+    assert state.engaged is False
+    assert state.lvc_state is LVCState.WARNING

--- a/src/wheelchair/safety/__init__.py
+++ b/src/wheelchair/safety/__init__.py
@@ -10,6 +10,7 @@ GPIO-level deadman wiring — are tracked in issues #20, #21, #22.
 from .current_limit import MotorCurrent, OvercurrentMonitor
 from .deadman import DeadmanSwitch
 from .estop import EmergencyStop, EStopEvent, EStopReason
+from .loop import SafetyLoop, SafetyState
 from .lvc import LowVoltageCutoff, LVCState
 from .tilt import TiltMonitor
 from .watchdog import CommandWatchdog, WatchdogExpired
@@ -26,4 +27,6 @@ __all__ = [
     "EmergencyStop",
     "EStopReason",
     "EStopEvent",
+    "SafetyLoop",
+    "SafetyState",
 ]

--- a/src/wheelchair/safety/loop.py
+++ b/src/wheelchair/safety/loop.py
@@ -1,0 +1,160 @@
+"""SafetyLoop — single integration point for every Phase-1 safety module.
+
+Callers (tele-op server, comma supervisor, HIL rig) shouldn't have to
+re-implement the wiring of CommandWatchdog + DeadmanSwitch + TiltMonitor
++ LowVoltageCutoff + OvercurrentMonitor + EmergencyStop. This module
+does it once.
+
+Design:
+- Every monitor is created with a `stop_callback` that fans into the
+  shared `EmergencyStop` coordinator with the matching `EStopReason`.
+- The control loop calls `step(...)` on every iteration with the
+  latest sensor + battery + current snapshot. `step()` is non-blocking
+  and returns the current `SafetyState`.
+- If `state.engaged` is True the caller MUST command motors to zero
+  (and the drive's hardware-level `EmergencyStop.hardware_gpio_drop`
+  already pulled the GPIO line low independently).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+from .current_limit import MotorCurrent, OvercurrentMonitor
+from .deadman import DeadmanSwitch
+from .estop import EmergencyStop, EStopReason
+from .lvc import LowVoltageCutoff, LVCState
+from .tilt import TiltMonitor
+from .watchdog import CommandWatchdog
+
+
+@dataclass
+class SafetyState:
+    """Snapshot returned from `SafetyLoop.step()`."""
+
+    engaged: bool
+    reason: Optional[EStopReason]
+    watchdog_alive: bool
+    deadman_alive: bool
+    tilt_tripped: bool
+    lvc_state: LVCState
+    overcurrent_tripped: bool
+
+
+@dataclass
+class SafetyLoop:
+    """Aggregator for every Phase-1 safety subsystem.
+
+    Args:
+        motor_stop: invoked once by EmergencyStop on first trip.
+        hardware_gpio_drop: invoked once on first trip; production
+            wiring pulls the e-stop relay's enable line low.
+        watchdog_timeout_s: max gap between feed() calls (default 100 ms).
+        deadman_timeout_s: max gap between press() calls (default 500 ms).
+        tilt_limit_deg / tilt_debounce_s: TiltMonitor parameters.
+        lvc_*: LowVoltageCutoff parameters.
+        oc_max_continuous_a / oc_max_peak_a / oc_peak_window_s:
+            OvercurrentMonitor parameters (per chair from WheelchairSpec.motor).
+    """
+
+    motor_stop: Callable[[], None]
+    hardware_gpio_drop: Callable[[], None] = lambda: None  # noqa: E731
+    watchdog_timeout_s: float = 0.1
+    deadman_timeout_s: float = 0.5
+    tilt_limit_deg: float = 25.0
+    tilt_debounce_s: float = 0.2
+    lvc_warn_v: float = 23.5
+    lvc_cutoff_v: float = 22.5
+    lvc_debounce_s: float = 1.0
+    oc_max_continuous_a: float = 30.0
+    oc_max_peak_a: float = 50.0
+    oc_peak_window_s: float = 0.1
+    _estop: EmergencyStop = field(init=False)
+    _watchdog: CommandWatchdog = field(init=False)
+    _deadman: DeadmanSwitch = field(init=False)
+    _tilt: TiltMonitor = field(init=False)
+    _lvc: LowVoltageCutoff = field(init=False)
+    _ocm: OvercurrentMonitor = field(init=False)
+
+    def __post_init__(self) -> None:
+        self._estop = EmergencyStop(
+            motor_stop=self.motor_stop,
+            hardware_gpio_drop=self.hardware_gpio_drop,
+        )
+        self._watchdog = CommandWatchdog(timeout_s=self.watchdog_timeout_s)
+        self._deadman = DeadmanSwitch(
+            timeout_s=self.deadman_timeout_s,
+            stop_callback=lambda: self._estop.engage(EStopReason.DEADMAN),
+        )
+        self._tilt = TiltMonitor(
+            limit_deg=self.tilt_limit_deg,
+            debounce_s=self.tilt_debounce_s,
+            stop_callback=lambda: self._estop.engage(EStopReason.TILT),
+        )
+        self._lvc = LowVoltageCutoff(
+            warn_v=self.lvc_warn_v,
+            cutoff_v=self.lvc_cutoff_v,
+            debounce_s=self.lvc_debounce_s,
+            stop_callback=lambda: self._estop.engage(EStopReason.LVC),
+        )
+        self._ocm = OvercurrentMonitor(
+            max_continuous_a=self.oc_max_continuous_a,
+            max_peak_a=self.oc_max_peak_a,
+            peak_window_s=self.oc_peak_window_s,
+            stop_callback=lambda: self._estop.engage(EStopReason.OVERCURRENT),
+        )
+
+    # ---- inputs ----
+
+    def feed_command(self) -> None:
+        """Call on every valid command from the tele-op server."""
+        self._watchdog.feed()
+
+    def deadman(self, pressed: bool) -> None:
+        if pressed:
+            self._deadman.press()
+        else:
+            self._deadman.release()
+
+    def update_imu(self, ax: float, ay: float, az: float) -> None:
+        self._tilt.update(ax, ay, az)
+
+    def update_battery(self, voltage_v: float) -> None:
+        self._lvc.update(voltage_v)
+
+    def update_current(self, left_a: float, right_a: float, ts_s: float) -> None:
+        self._ocm.update(MotorCurrent(left_a=left_a, right_a=right_a, timestamp_s=ts_s))
+
+    def operator_estop(self, detail: str = "") -> None:
+        self._estop.engage(EStopReason.OPERATOR, detail)
+
+    # ---- per-tick step ----
+
+    def step(self) -> SafetyState:
+        """Run all checks and return the current state."""
+        # The watchdog isn't a callback-style monitor; check it here.
+        if not self._watchdog.is_alive():
+            self._estop.engage(EStopReason.WATCHDOG)
+        self._deadman.check()  # fires stop on expiry
+        return SafetyState(
+            engaged=self._estop.is_engaged(),
+            reason=self._estop.event.reason if self._estop.event else None,
+            watchdog_alive=self._watchdog.is_alive(),
+            deadman_alive=not self._deadman.stopped,
+            tilt_tripped=self._tilt.tripped,
+            lvc_state=self._lvc.state,
+            overcurrent_tripped=self._ocm.tripped,
+        )
+
+    # ---- ops ----
+
+    def clear(self, operator_confirm: bool = False) -> None:
+        """Release the latched e-stop. Requires explicit confirmation."""
+        self._estop.clear(operator_confirm=operator_confirm)
+        # Reset stateful monitors so the next step() doesn't immediately retrip.
+        self._tilt.reset()
+
+    @property
+    def estop(self) -> EmergencyStop:
+        return self._estop


### PR DESCRIPTION
Wires Phase-1 SafetyLoop into the FastAPI tele-op server's safety_stop/feed_watchdog hooks and proves the contract holds under MOVE / DEADMAN / STOP / disconnect / watchdog-expiry. 6/6 @pytest.mark.safety integration tests pass; full safety suite across the merged tree: 42/42. Branch merges in phase-1/safety-loop so it can import SafetyLoop. Refs #19, #21, #25, #45.