### PR TITLE
phase-0(keyboard): drop `keyboard` lib; rewrite KeyboardControl on input() (G-22)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,10 @@
 # Uncomment the following line when running on Raspberry Pi:
 RPi.GPIO>=0.7.1
 
-# Optional: For enhanced keyboard control
-keyboard>=0.13.5
+# `keyboard>=0.13.5` removed in audit gap G-22:
+#  - requires root + TTY (broken in containers, CI, headless boots)
+#  - real-time input belongs on the client side, not the Pi
+#  - `wheelchair_controller.keyboard_control` now uses line-buffered input()
 
 # Development dependencies (optional)
 pytest>=7.4.0

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ setup(
     ],
     extras_require={
         "rpi": ["RPi.GPIO>=0.7.1"],
-        "keyboard": ["keyboard>=0.13.5"],
+        # `keyboard` extra removed in audit gap G-22 — see
+        # wheelchair_controller/keyboard_control.py for the rationale.
         "dev": [
             "pytest>=7.4.0",
             "pytest-cov>=4.1.0",

--- a/src/tests/test_keyboard_control.py
+++ b/src/tests/test_keyboard_control.py
@@ -1,0 +1,73 @@
+"""Tests for the post-G-22 KeyboardControl loop.
+
+Confirms it works without the `keyboard` library, without root, and
+without a TTY (the old failure modes the audit flagged).
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from wheelchair_controller.keyboard_control import KeyboardControl
+
+
+class FakeController:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def move_forward(self) -> None:
+        self.calls.append("forward")
+
+    def move_backward(self) -> None:
+        self.calls.append("backward")
+
+    def turn_left(self) -> None:
+        self.calls.append("left")
+
+    def turn_right(self) -> None:
+        self.calls.append("right")
+
+    def stop(self) -> None:
+        self.calls.append("stop")
+
+
+def _run_with_stdin(stdin: str, monkeypatch: pytest.MonkeyPatch) -> FakeController:
+    """Drive the KeyboardControl loop with a scripted stdin and return
+    the FakeController call log."""
+    monkeypatch.setattr("sys.stdin", io.StringIO(stdin))
+    ctl = FakeController()
+    kc = KeyboardControl(ctl)
+    kc.run()
+    return ctl
+
+
+def test_each_command_dispatches(monkeypatch: pytest.MonkeyPatch) -> None:
+    ctl = _run_with_stdin("w\ns\na\nd\n\nq\n", monkeypatch)
+    # The final stop comes from the run() finally-clause.
+    assert ctl.calls == ["forward", "backward", "left", "right", "stop", "stop"]
+
+
+def test_quit_aliases(monkeypatch: pytest.MonkeyPatch) -> None:
+    ctl = _run_with_stdin("quit\n", monkeypatch)
+    assert ctl.calls == ["stop"]
+
+
+def test_unknown_command_does_not_crash(monkeypatch: pytest.MonkeyPatch) -> None:
+    ctl = _run_with_stdin("xyzzy\nq\n", monkeypatch)
+    assert ctl.calls == ["stop"]
+
+
+def test_eof_exits_cleanly_with_stop(monkeypatch: pytest.MonkeyPatch) -> None:
+    ctl = _run_with_stdin("", monkeypatch)  # immediate EOF
+    assert ctl.calls == ["stop"]
+
+
+def test_no_root_and_no_keyboard_module_required() -> None:
+    """The whole point of G-22 — no import-time dependency on `keyboard`."""
+    import wheelchair_controller.keyboard_control as kc_module
+
+    src = open(kc_module.__file__).read()
+    assert "import keyboard" not in src
+    assert "from keyboard" not in src

--- a/wheelchair_controller/keyboard_control.py
+++ b/wheelchair_controller/keyboard_control.py
@@ -1,141 +1,99 @@
-"""Keyboard control interface for wheelchair controller."""
+"""Keyboard control for the legacy main.py entry point.
+
+Closes audit gap G-22 by removing the `keyboard` Python library
+dependency. The previous implementation tried to import `keyboard` for
+"real-time" key detection — which only works as root, only with a TTY,
+and refuses to load in Docker. Both failure modes hit production users.
+
+The right place for real-time low-latency input is the **client**
+(Android joystick or web UI), not the Pi reading its own attached
+keyboard. The Pi exposes the WebSocket control endpoint
+(`wheelchair.app.server` from Phase 2) and the client sends frames.
+
+This module is kept only for the legacy `python main.py` command:
+line-buffered ``input()``-based control. It's intentionally simple
+and intentionally not real-time; if you need real-time, use the
+tele-op WS client.
+"""
+
+from __future__ import annotations
 
 import logging
 import sys
-import time
-from typing import Optional
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
 
 class KeyboardControl:
-    """Keyboard control interface for wheelchair."""
-    
-    def __init__(self, controller):
-        """
-        Initialize keyboard control.
-        
-        Args:
-            controller: WheelchairController instance
-        """
+    """Line-buffered keyboard control. No external lib, no root."""
+
+    def __init__(self, controller: Any) -> None:
         self.controller = controller
         self.running = False
-    
-    def print_instructions(self):
-        """Print control instructions."""
-        print("\n" + "="*50)
-        print("Wheelchair Controller - Keyboard Control")
-        print("="*50)
-        print("Controls:")
-        print("  W/w - Move Forward")
-        print("  S/s - Move Backward")
-        print("  A/a - Turn Left")
-        print("  D/d - Turn Right")
-        print("  Space - Stop")
-        print("  Q/q - Quit")
-        print("="*50 + "\n")
-    
-    def run(self):
-        """Run keyboard control loop."""
+
+    def print_instructions(self) -> None:
+        print(
+            "\n"
+            + "=" * 50
+            + "\n"
+            "Wheelchair Controller — line-buffered keyboard input\n"
+            + "=" * 50
+            + "\n"
+            "Type a letter and press <Enter>:\n"
+            "  w — forward       a — left\n"
+            "  s — backward      d — right\n"
+            "  (blank) — stop    q — quit\n"
+            "\n"
+            "For real-time control use the WS tele-op client (web/Android),\n"
+            "not this loop.\n"
+            + "=" * 50
+            + "\n",
+            flush=True,
+        )
+
+    def run(self) -> None:
         self.print_instructions()
         self.running = True
-        
-        try:
-            # Try to use keyboard library if available
-            import keyboard
-            self._run_with_keyboard_lib()
-        except ImportError:
-            logger.info("keyboard library not available, using basic input mode")
-            self._run_with_input()
-    
-    def _run_with_input(self):
-        """Run control using basic input (works without keyboard library)."""
-        print("Enter command (w/s/a/d/space/q): ")
-        
-        while self.running:
-            try:
-                command = input("> ").lower().strip()
-                
-                if command == 'w':
-                    print("Moving forward...")
-                    self.controller.move_forward()
-                elif command == 's':
-                    print("Moving backward...")
-                    self.controller.move_backward()
-                elif command == 'a':
-                    print("Turning left...")
-                    self.controller.turn_left()
-                elif command == 'd':
-                    print("Turning right...")
-                    self.controller.turn_right()
-                elif command == ' ' or command == '':
-                    print("Stopping...")
-                    self.controller.stop()
-                elif command == 'q':
-                    print("Quitting...")
-                    self.running = False
-                else:
-                    print(f"Unknown command: {command}")
-                    
-            except KeyboardInterrupt:
-                print("\nKeyboard interrupt received")
-                self.running = False
-            except EOFError:
-                self.running = False
-    
-    def _run_with_keyboard_lib(self):
-        """Run control using keyboard library (real-time key detection)."""
-        import keyboard
-        
-        print("Real-time keyboard control active. Press Q to quit.")
-        print("Hold keys for continuous movement.\n")
-        
-        last_key = None
-        
         try:
             while self.running:
-                if keyboard.is_pressed('q'):
-                    print("Quitting...")
-                    self.running = False
+                command = self._read_command()
+                if command is None:
                     break
-                elif keyboard.is_pressed('w'):
-                    if last_key != 'w':
-                        print("Moving forward...")
-                        self.controller.move_forward()
-                        last_key = 'w'
-                elif keyboard.is_pressed('s'):
-                    if last_key != 's':
-                        print("Moving backward...")
-                        self.controller.move_backward()
-                        last_key = 's'
-                elif keyboard.is_pressed('a'):
-                    if last_key != 'a':
-                        print("Turning left...")
-                        self.controller.turn_left()
-                        last_key = 'a'
-                elif keyboard.is_pressed('d'):
-                    if last_key != 'd':
-                        print("Turning right...")
-                        self.controller.turn_right()
-                        last_key = 'd'
-                elif keyboard.is_pressed('space'):
-                    if last_key != 'space':
-                        print("Stopping...")
-                        self.controller.stop()
-                        last_key = 'space'
-                else:
-                    if last_key is not None:
-                        self.controller.stop()
-                        last_key = None
-                
-                time.sleep(0.05)  # Small delay to prevent CPU spinning
-                
-        except KeyboardInterrupt:
-            print("\nKeyboard interrupt received")
-        
-        self.controller.stop()
-    
-    def cleanup(self):
-        """Cleanup resources."""
+                self._dispatch(command)
+        finally:
+            self.controller.stop()
+
+    def _read_command(self) -> str | None:
+        try:
+            line = input("> ")
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return None
+        return line.lower().strip()
+
+    def _dispatch(self, command: str) -> None:
+        if command in ("w", "forward"):
+            print("forward")
+            self.controller.move_forward()
+        elif command in ("s", "backward", "back"):
+            print("backward")
+            self.controller.move_backward()
+        elif command in ("a", "left"):
+            print("left")
+            self.controller.turn_left()
+        elif command in ("d", "right"):
+            print("right")
+            self.controller.turn_right()
+        elif command in ("", " ", "stop"):
+            print("stop")
+            self.controller.stop()
+        elif command in ("q", "quit", "exit"):
+            print("quit")
+            self.running = False
+        else:
+            print(f"unknown: {command!r} (try: w/s/a/d/<blank>/q)", file=sys.stderr)
+
+    def cleanup(self) -> None:
         self.running = False
         self.controller.stop()


### PR DESCRIPTION
Closes G-22. The `keyboard` lib requires root + TTY (broken in Docker, CI, headless boots). Rewrites KeyboardControl to use line-buffered input(); removes the dep from requirements.txt + setup.py. Real-time input belongs on the client (WS tele-op from Phase 2), not on the Pi. 5/5 new tests pass including a guard test that the module source contains no `import keyboard`. Refs #40.