### PR TITLE
phase-3(canonical): main.py constructs hardware drive via L298NDrive (G-09)

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,10 +1,24 @@
 #!/usr/bin/env python3
-"""Main entry point for wheelchair controller application."""
+"""Main entry point for wheelchair controller application.
+
+Phase-0 cleanup (audit gap G-09): the hardware drive is now constructed
+through the canonical ``wheelchair.drives.hardware.l298n.L298NDrive``
+ABC implementation. The legacy ``WheelchairController`` from
+``wheelchair_controller`` is kept for back-compat — it consumes the
+underlying ``MotorDriver`` instance that ``L298NDrive`` already manages
+via its ``motor_driver`` property.
+
+End-state (after Phase 0 deletions): main.py will be replaced by a
+thin shim around ``wheelchair.cli`` and the legacy
+``wheelchair_controller`` package will be deleted entirely.
+"""
 
 import argparse
 import logging
 import sys
-from wheelchair_controller import WheelchairController, MotorDriver
+
+from wheelchair.drives.hardware.l298n import L298NDrive
+from wheelchair_controller import WheelchairController
 from wheelchair_controller.keyboard_control import KeyboardControl
 
 
@@ -14,9 +28,7 @@ def setup_logging(verbose: bool = False):
     logging.basicConfig(
         level=level,
         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        handlers=[
-            logging.StreamHandler(sys.stdout)
-        ]
+        handlers=[logging.StreamHandler(sys.stdout)],
     )
 
 
@@ -28,60 +40,59 @@ def main():
     parser.add_argument(
         '--mock',
         action='store_true',
-        help='Use mock GPIO (for testing without Raspberry Pi)'
+        help='Use mock GPIO (for testing without Raspberry Pi)',
     )
     parser.add_argument(
         '--max-speed',
         type=int,
         default=80,
-        help='Maximum speed percentage (0-100, default: 80)'
+        help='Maximum speed percentage (0-100, default: 80)',
     )
     parser.add_argument(
         '--turn-speed',
         type=int,
         default=60,
-        help='Turn speed percentage (0-100, default: 60)'
+        help='Turn speed percentage (0-100, default: 60)',
     )
     parser.add_argument(
         '--verbose', '-v',
         action='store_true',
-        help='Enable verbose logging'
+        help='Enable verbose logging',
     )
-    
+
     args = parser.parse_args()
-    
+
     setup_logging(args.verbose)
     logger = logging.getLogger(__name__)
-    
+
+    controller = None
     try:
         logger.info("Starting Wheelchair Controller")
-        
-        # Initialize motor driver
-        motor_driver = MotorDriver(use_mock=args.mock)
-        
-        # Initialize controller
+
+        # Canonical drive (Phase 0 / G-09): WheelchairDrive ABC wrapping
+        # the legacy MotorDriver. We hand the wrapped MotorDriver to
+        # WheelchairController for back-compat with the keyboard loop.
+        drive = L298NDrive(use_mock=args.mock)
+
         controller = WheelchairController(
-            motor_driver=motor_driver,
+            motor_driver=drive.motor_driver,
             max_speed=args.max_speed,
-            turn_speed=args.turn_speed
+            turn_speed=args.turn_speed,
         )
-        
-        # Initialize keyboard control
+
         keyboard_control = KeyboardControl(controller)
-        
-        # Run control loop
         keyboard_control.run()
-        
+
     except KeyboardInterrupt:
         logger.info("Received keyboard interrupt")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         logger.error(f"Error: {e}", exc_info=True)
         return 1
     finally:
         logger.info("Shutting down...")
-        if 'controller' in locals():
+        if controller is not None:
             controller.cleanup()
-    
+
     logger.info("Shutdown complete")
     return 0
 

--- a/src/tests/test_main_uses_canonical_drive.py
+++ b/src/tests/test_main_uses_canonical_drive.py
@@ -1,0 +1,67 @@
+"""Tests for the post-G-09 main.py.
+
+Confirms that main.py:
+- imports the canonical L298NDrive (not the legacy MotorDriver directly)
+- constructs WheelchairController via L298NDrive.motor_driver
+- still works in --mock mode end-to-end
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import io
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+MAIN_PY = REPO_ROOT / "main.py"
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text())
+    mods: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for n in node.names:
+                mods.add(n.name)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            mods.add(node.module)
+    return mods
+
+
+def test_main_imports_canonical_drive() -> None:
+    mods = _imported_modules(MAIN_PY)
+    assert "wheelchair.drives.hardware.l298n" in mods
+
+
+def test_main_does_not_import_motor_driver_directly() -> None:
+    """G-09: hardware drive must go through L298NDrive, not raw MotorDriver."""
+    mods = _imported_modules(MAIN_PY)
+    assert "wheelchair_controller.motor_driver" not in mods
+
+
+def test_l298n_exposes_motor_driver_property() -> None:
+    from wheelchair.drives.hardware.l298n import L298NDrive
+
+    drive = L298NDrive(use_mock=True)
+    assert drive.motor_driver is drive._md
+    # Property should be usable as a MotorDriver-typed handle.
+    assert hasattr(drive.motor_driver, "set_motor_speed")
+    assert hasattr(drive.motor_driver, "stop")
+
+
+def test_main_smoke_runs_under_mock(monkeypatch: pytest.MonkeyPatch) -> None:
+    """End-to-end smoke: invoke main() with --mock and an empty stdin."""
+    import importlib.util
+
+    monkeypatch.setattr("sys.argv", ["main.py", "--mock"])
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))  # immediate EOF on input()
+    spec = importlib.util.spec_from_file_location("wcbot_main_smoke", MAIN_PY)
+    assert spec and spec.loader
+    main_mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(main_mod)
+    rc = main_mod.main()
+    assert rc == 0

--- a/src/wheelchair/drives/hardware/l298n.py
+++ b/src/wheelchair/drives/hardware/l298n.py
@@ -44,6 +44,18 @@ class L298NDrive(WheelchairDrive):
         self._left = 0.0
         self._right = 0.0
 
+    @property
+    def motor_driver(self):
+        """Legacy ``MotorDriver`` instance.
+
+        Exposed so callers still using the legacy ``WheelchairController``
+        API (e.g. main.py before its Phase-0 cleanup) can construct it
+        from the canonical ``L298NDrive`` instead of importing
+        ``MotorDriver`` directly. New code should drive through
+        ``set_motor_speeds`` instead.
+        """
+        return self._md
+
     def set_motor_speeds(self, left: float, right: float) -> None:
         self._left = max(-1.0, min(1.0, left))
         self._right = max(-1.0, min(1.0, right))


### PR DESCRIPTION
Closes G-09. main.py now imports the canonical L298NDrive instead of MotorDriver. A new `motor_driver` property on L298NDrive exposes the wrapped legacy instance so WheelchairController (back-compat keyboard loop) still works. 4/4 new tests pass including a --mock smoke test that runs the full main() invocation. Refs #27, #33.